### PR TITLE
Ensure TextToSpeech playback runs on main thread

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,19 @@ A simple Android application that lets you control your PC remotely using voice 
 - 🔒 Secure communication using TLS encryption
 - 🔄 CI/CD with automatic builds via GitHub Actions
 
+## 🔊 Text-to-Speech (TTS)
+
+This app now initializes Android’s native `TextToSpeech` engine in the audio service to speak
+server responses when no audio file is available (no extra dependencies needed beyond the
+Android SDK). The response text currently comes from the `result` field in
+`AudioService.processJsonResponse()` and is passed to `createTextToSpeechResponse(...)`, which
+uses `TextToSpeechManager.speak(...)`.
+
+**Para más adelante:** si el backend cambia el formato, o si quieres priorizar otro campo,
+ajusta la llamada a `createTextToSpeechResponse(...)` dentro de `processJsonResponse()` para
+pasar el texto correcto. El siguiente paso sería guardar el audio sintetizado en un archivo
+(por ejemplo `response_audio.ogg`) para que se pueda reproducir como cualquier otra respuesta.
+
 ## 🚀 Getting Started
 
 0. 📦 Build the app from source (Android Studio or gradlew...)

--- a/app/src/main/java/com/example/myapplication/AudioService.kt
+++ b/app/src/main/java/com/example/myapplication/AudioService.kt
@@ -647,7 +647,7 @@ class AudioService : Service() {
                             Log.e("AudioSending", "La respuesta del servidor está vacía")
                             sendErrorMessage(getString(R.string.empty_response))
                             // Send response received signal for empty response
-                            sendBroadcast(Intent(ACTION_RESPONSE_RECEIVED).apply {
+                            sendAppBroadcast(Intent(ACTION_RESPONSE_RECEIVED).apply {
                                 putExtra(EXTRA_RESPONSE_MESSAGE, getString(R.string.empty_response))
                                 putExtra(EXTRA_RESPONSE_SUCCESS, false)
                             })
@@ -675,7 +675,7 @@ class AudioService : Service() {
                                     sendLogMessage(getString(R.string.warning, errorMessage))
                                     sendErrorMessage(errorMessage)
                                     // Send response received signal for error
-                                    sendBroadcast(Intent(ACTION_RESPONSE_RECEIVED).apply {
+                                    sendAppBroadcast(Intent(ACTION_RESPONSE_RECEIVED).apply {
                                         putExtra(EXTRA_RESPONSE_MESSAGE, errorMessage)
                                         putExtra(EXTRA_RESPONSE_SUCCESS, false)
                                     })
@@ -704,7 +704,7 @@ class AudioService : Service() {
                                         )
                                     }
                                     // Send response received signal for no command detected
-                                    sendBroadcast(Intent(ACTION_RESPONSE_RECEIVED).apply {
+                                    sendAppBroadcast(Intent(ACTION_RESPONSE_RECEIVED).apply {
                                         putExtra(EXTRA_RESPONSE_MESSAGE, getString(R.string.no_command_detected_message))
                                         putExtra(EXTRA_RESPONSE_SUCCESS, false)
                                     })
@@ -714,7 +714,7 @@ class AudioService : Service() {
                                     // Other error cases
                                     sendErrorMessage(getString(R.string.server_error, errorMessage))
                                     // Send response received signal for other errors
-                                    sendBroadcast(Intent(ACTION_RESPONSE_RECEIVED).apply {
+                                    sendAppBroadcast(Intent(ACTION_RESPONSE_RECEIVED).apply {
                                         putExtra(EXTRA_RESPONSE_MESSAGE, errorMessage)
                                         putExtra(EXTRA_RESPONSE_SUCCESS, false)
                                     })
@@ -725,7 +725,7 @@ class AudioService : Service() {
                                 Log.e("AudioSending", "Error parsing error response: ${e.message}")
                                 sendErrorMessage(getString(R.string.error_processing_response, e.message))
                                 // Send response received signal for parsing error
-                                sendBroadcast(Intent(ACTION_RESPONSE_RECEIVED).apply {
+                                sendAppBroadcast(Intent(ACTION_RESPONSE_RECEIVED).apply {
                                     putExtra(EXTRA_RESPONSE_MESSAGE, getString(R.string.error_processing_response, e.message))
                                     putExtra(EXTRA_RESPONSE_SUCCESS, false)
                                 })
@@ -735,7 +735,7 @@ class AudioService : Service() {
                             // Generic HTTP error
                             sendErrorMessage(getString(R.string.http_error, response.code, response.message))
                             // Send response received signal for HTTP error
-                            sendBroadcast(Intent(ACTION_RESPONSE_RECEIVED).apply {
+                            sendAppBroadcast(Intent(ACTION_RESPONSE_RECEIVED).apply {
                                 putExtra(EXTRA_RESPONSE_MESSAGE, getString(R.string.http_error, response.code, response.message))
                                 putExtra(EXTRA_RESPONSE_SUCCESS, false)
                             })
@@ -748,7 +748,7 @@ class AudioService : Service() {
                     Log.e("AudioSending", "Error de red", e)
                     sendErrorMessage(getString(R.string.network_error, e.message ?: getString(R.string.connection_failed)))
                     // Send response received signal for network error
-                    sendBroadcast(Intent(ACTION_RESPONSE_RECEIVED).apply {
+                    sendAppBroadcast(Intent(ACTION_RESPONSE_RECEIVED).apply {
                         putExtra(EXTRA_RESPONSE_MESSAGE, getString(R.string.network_error, e.message ?: getString(R.string.connection_failed)))
                         putExtra(EXTRA_RESPONSE_SUCCESS, false)
                     })
@@ -760,7 +760,7 @@ class AudioService : Service() {
                 Log.e("AudioSending", "Error inesperado", e)
                 sendErrorMessage(getString(R.string.error_unexpected, e.message ?: e.javaClass.simpleName))
                 // Send response received signal for unexpected error
-                sendBroadcast(Intent(ACTION_RESPONSE_RECEIVED).apply {
+                sendAppBroadcast(Intent(ACTION_RESPONSE_RECEIVED).apply {
                     putExtra(EXTRA_RESPONSE_MESSAGE, getString(R.string.error_unexpected, e.message ?: e.javaClass.simpleName))
                     putExtra(EXTRA_RESPONSE_SUCCESS, false)
                 })
@@ -772,7 +772,7 @@ class AudioService : Service() {
             Log.e("AudioSending", "Error inesperado", e)
             sendErrorMessage(getString(R.string.error_unexpected, e.message ?: e.javaClass.simpleName))
             // Send response received signal for outer exception
-            sendBroadcast(Intent(ACTION_RESPONSE_RECEIVED).apply {
+            sendAppBroadcast(Intent(ACTION_RESPONSE_RECEIVED).apply {
                 putExtra(EXTRA_RESPONSE_MESSAGE, getString(R.string.error_unexpected, e.message ?: e.javaClass.simpleName))
                 putExtra(EXTRA_RESPONSE_SUCCESS, false)
             })
@@ -802,7 +802,7 @@ class AudioService : Service() {
                 if (status == "error") {
                     sendErrorMessage(errorMessage)
                     // Send response received signal for error case too
-                    sendBroadcast(Intent(ACTION_RESPONSE_RECEIVED).apply {
+                    sendAppBroadcast(Intent(ACTION_RESPONSE_RECEIVED).apply {
                         putExtra(EXTRA_RESPONSE_MESSAGE, errorMessage)
                         putExtra(EXTRA_RESPONSE_SUCCESS, false)
                     })
@@ -831,7 +831,7 @@ class AudioService : Service() {
                 // Signal completion with error
                 sendErrorMessage(errorMessage)
                 // Send response received signal for error case too
-                sendBroadcast(Intent(ACTION_RESPONSE_RECEIVED).apply {
+                sendAppBroadcast(Intent(ACTION_RESPONSE_RECEIVED).apply {
                     putExtra(EXTRA_RESPONSE_MESSAGE, errorMessage)
                     putExtra(EXTRA_RESPONSE_SUCCESS, false)
                 })
@@ -886,7 +886,7 @@ class AudioService : Service() {
                 serviceScope.launch(Dispatchers.IO) {
                     downloadAudioResponse(transcription)
                     // Send response received signal
-                    sendBroadcast(Intent(ACTION_RESPONSE_RECEIVED).apply {
+                    sendAppBroadcast(Intent(ACTION_RESPONSE_RECEIVED).apply {
                         putExtra(EXTRA_RESPONSE_MESSAGE, responseMessage)
                         putExtra(EXTRA_RESPONSE_SUCCESS, success)
                         putExtra(EXTRA_SCREEN_SUMMARY, summaryForUi)
@@ -899,7 +899,7 @@ class AudioService : Service() {
                 serviceScope.launch(Dispatchers.IO) {
                     createTextToSpeechResponse(transcription, responseMessage)
                     // Send response received signal
-                    sendBroadcast(Intent(ACTION_RESPONSE_RECEIVED).apply {
+                    sendAppBroadcast(Intent(ACTION_RESPONSE_RECEIVED).apply {
                         putExtra(EXTRA_RESPONSE_MESSAGE, responseMessage)
                         putExtra(EXTRA_RESPONSE_SUCCESS, success)
                         putExtra(EXTRA_SCREEN_SUMMARY, summaryForUi)
@@ -913,7 +913,7 @@ class AudioService : Service() {
             Log.e("AudioResponse", "Error al procesar respuesta JSON", e)
             sendErrorMessage(getString(R.string.error_processing_response, e.message))
             // Send response received signal for JSON processing error
-            sendBroadcast(Intent(ACTION_RESPONSE_RECEIVED).apply {
+            sendAppBroadcast(Intent(ACTION_RESPONSE_RECEIVED).apply {
                 putExtra(EXTRA_RESPONSE_MESSAGE, getString(R.string.error_processing_response, e.message))
                 putExtra(EXTRA_RESPONSE_SUCCESS, false)
             })
@@ -943,7 +943,7 @@ class AudioService : Service() {
                     
                     // Announce the response is ready
                     sendAudioFileInfo(responseFile, "response")
-                    sendBroadcast(Intent(ACTION_RESPONSE_RECEIVED).apply {
+                    sendAppBroadcast(Intent(ACTION_RESPONSE_RECEIVED).apply {
                         putExtra(EXTRA_RESPONSE_MESSAGE, getString(R.string.test_mode_tts_ready))
                         putExtra(EXTRA_RESPONSE_SUCCESS, true)
                     })
@@ -964,7 +964,7 @@ class AudioService : Service() {
             }
             
             // Broadcast that we have a "response" even though it's just text
-            sendBroadcast(Intent(ACTION_RESPONSE_RECEIVED).apply {
+            sendAppBroadcast(Intent(ACTION_RESPONSE_RECEIVED).apply {
                 putExtra(EXTRA_RESPONSE_MESSAGE, getString(R.string.playing_audio_response))
                 putExtra(EXTRA_RESPONSE_SUCCESS, true)
             })
@@ -1119,7 +1119,7 @@ class AudioService : Service() {
                 
                 // Now let's announce we received a response
                 sendAudioFileInfo(responseFile, "response")
-                sendBroadcast(Intent(ACTION_RESPONSE_RECEIVED))
+                sendAppBroadcast(Intent(ACTION_RESPONSE_RECEIVED))
                 
                 sendLogMessage(getString(R.string.test_mode_response_created, responseFile.length()))
             } else {
@@ -1139,7 +1139,7 @@ class AudioService : Service() {
                 
                 // Now let's announce we received a response
                 sendAudioFileInfo(responseFile, "response")
-                sendBroadcast(Intent(ACTION_RESPONSE_RECEIVED))
+                sendAppBroadcast(Intent(ACTION_RESPONSE_RECEIVED))
                 
                 sendLogMessage(getString(R.string.test_mode_empty_response_created, responseFile.length()))
             }
@@ -1238,7 +1238,7 @@ class AudioService : Service() {
             }
             
             sendLogMessage(getString(R.string.playing_audio_response))
-            sendBroadcast(Intent(ACTION_RESPONSE_RECEIVED))
+            sendAppBroadcast(Intent(ACTION_RESPONSE_RECEIVED))
         } catch (e: Exception) {
             sendLogMessage(getString(R.string.error_playing_audio, e.message))
         }
@@ -1283,7 +1283,7 @@ class AudioService : Service() {
         val intent = Intent(ACTION_LOG_MESSAGE).apply {
             putExtra(EXTRA_LOG_MESSAGE, errorMessage)
         }
-        sendBroadcast(intent)
+        sendAppBroadcast(intent)
     }
 
     /**
@@ -1291,11 +1291,16 @@ class AudioService : Service() {
      * This can be used to hide progress indicators
      */
     private fun signalProcessingComplete() {
-        sendBroadcast(Intent(ACTION_PROCESSING_COMPLETED))
+        sendAppBroadcast(Intent(ACTION_PROCESSING_COMPLETED))
+    }
+
+    private fun sendAppBroadcast(intent: Intent) {
+        intent.setPackage(packageName)
+        sendBroadcast(intent)
     }
 
     private fun sendTtsStatus(status: String) {
-        sendBroadcast(Intent(ACTION_TTS_STATUS).apply {
+        sendAppBroadcast(Intent(ACTION_TTS_STATUS).apply {
             putExtra(EXTRA_TTS_STATUS, status)
         })
     }

--- a/app/src/main/java/com/example/myapplication/AudioService.kt
+++ b/app/src/main/java/com/example/myapplication/AudioService.kt
@@ -963,11 +963,7 @@ class AudioService : Service() {
                 }
             }
             
-            // Broadcast that we have a "response" even though it's just text
-            sendAppBroadcast(Intent(ACTION_RESPONSE_RECEIVED).apply {
-                putExtra(EXTRA_RESPONSE_MESSAGE, getString(R.string.playing_audio_response))
-                putExtra(EXTRA_RESPONSE_SUCCESS, true)
-            })
+            // No extra response broadcast here; processJsonResponse already notifies the UI.
         }
     }
 

--- a/app/src/main/java/com/example/myapplication/TextToSpeechManager.kt
+++ b/app/src/main/java/com/example/myapplication/TextToSpeechManager.kt
@@ -3,6 +3,8 @@ package com.example.myapplication
 import android.content.Context
 import android.speech.tts.TextToSpeech
 import android.speech.tts.UtteranceProgressListener
+import android.os.Handler
+import android.os.Looper
 import android.util.Log
 import java.util.Locale
 import java.util.UUID
@@ -20,26 +22,27 @@ class TextToSpeechManager(
     private var ttsLocale: Locale = Locale("es", "ES")
     private var ttsRate: Float = 1.0f
     private var ttsPitch: Float = 1.0f
+    private val mainHandler = Handler(Looper.getMainLooper())
 
     override fun onInit(status: Int) {
         isReady = status == TextToSpeech.SUCCESS
         if (isReady) {
             textToSpeech.setOnUtteranceProgressListener(object : UtteranceProgressListener() {
                 override fun onStart(utteranceId: String) {
-                    onSpeakStart()
+                    mainHandler.post { onSpeakStart() }
                 }
 
                 override fun onDone(utteranceId: String) {
-                    onSpeakDone()
+                    mainHandler.post { onSpeakDone() }
                 }
 
                 @Deprecated("Deprecated in Java")
                 override fun onError(utteranceId: String) {
-                    onSpeakError(null)
+                    mainHandler.post { onSpeakError(null) }
                 }
 
                 override fun onError(utteranceId: String, errorCode: Int) {
-                    onSpeakError(errorCode.toString())
+                    mainHandler.post { onSpeakError(errorCode.toString()) }
                 }
             })
             val languageResult = textToSpeech.setLanguage(ttsLocale)

--- a/app/src/main/java/com/example/myapplication/TextToSpeechManager.kt
+++ b/app/src/main/java/com/example/myapplication/TextToSpeechManager.kt
@@ -1,0 +1,45 @@
+package com.example.myapplication
+
+import android.content.Context
+import android.speech.tts.TextToSpeech
+import android.util.Log
+import java.util.Locale
+import java.util.UUID
+
+class TextToSpeechManager(
+    context: Context,
+    private val onReadyChanged: (Boolean) -> Unit = {}
+) : TextToSpeech.OnInitListener {
+
+    private val textToSpeech: TextToSpeech = TextToSpeech(context.applicationContext, this)
+    private var isReady: Boolean = false
+
+    override fun onInit(status: Int) {
+        isReady = status == TextToSpeech.SUCCESS
+        if (isReady) {
+            val languageResult = textToSpeech.setLanguage(Locale.getDefault())
+            if (languageResult == TextToSpeech.LANG_MISSING_DATA ||
+                languageResult == TextToSpeech.LANG_NOT_SUPPORTED
+            ) {
+                Log.w("TextToSpeech", "Default language not supported")
+                isReady = false
+            }
+        } else {
+            Log.e("TextToSpeech", "Failed to initialize TextToSpeech")
+        }
+        onReadyChanged(isReady)
+    }
+
+    fun speak(text: String, utteranceId: String = UUID.randomUUID().toString()): Boolean {
+        if (!isReady || text.isBlank()) {
+            return false
+        }
+        textToSpeech.speak(text, TextToSpeech.QUEUE_FLUSH, null, utteranceId)
+        return true
+    }
+
+    fun shutdown() {
+        textToSpeech.stop()
+        textToSpeech.shutdown()
+    }
+}

--- a/app/src/main/java/com/example/myapplication/TextToSpeechManager.kt
+++ b/app/src/main/java/com/example/myapplication/TextToSpeechManager.kt
@@ -17,7 +17,7 @@ class TextToSpeechManager(
     override fun onInit(status: Int) {
         isReady = status == TextToSpeech.SUCCESS
         if (isReady) {
-            val languageResult = textToSpeech.setLanguage(Locale.getDefault())
+            val languageResult = textToSpeech.setLanguage(Locale("es", "ES"))
             if (languageResult == TextToSpeech.LANG_MISSING_DATA ||
                 languageResult == TextToSpeech.LANG_NOT_SUPPORTED
             ) {

--- a/app/src/main/java/com/example/myapplication/TextToSpeechManager.kt
+++ b/app/src/main/java/com/example/myapplication/TextToSpeechManager.kt
@@ -2,22 +2,47 @@ package com.example.myapplication
 
 import android.content.Context
 import android.speech.tts.TextToSpeech
+import android.speech.tts.UtteranceProgressListener
 import android.util.Log
 import java.util.Locale
 import java.util.UUID
 
 class TextToSpeechManager(
     context: Context,
-    private val onReadyChanged: (Boolean) -> Unit = {}
+    private val onReadyChanged: (Boolean) -> Unit = {},
+    private val onSpeakStart: () -> Unit = {},
+    private val onSpeakDone: () -> Unit = {},
+    private val onSpeakError: (String?) -> Unit = {}
 ) : TextToSpeech.OnInitListener {
 
     private val textToSpeech: TextToSpeech = TextToSpeech(context.applicationContext, this)
     private var isReady: Boolean = false
+    private var ttsLocale: Locale = Locale("es", "ES")
+    private var ttsRate: Float = 1.0f
+    private var ttsPitch: Float = 1.0f
 
     override fun onInit(status: Int) {
         isReady = status == TextToSpeech.SUCCESS
         if (isReady) {
-            val languageResult = textToSpeech.setLanguage(Locale("es", "ES"))
+            textToSpeech.setOnUtteranceProgressListener(object : UtteranceProgressListener() {
+                override fun onStart(utteranceId: String) {
+                    onSpeakStart()
+                }
+
+                override fun onDone(utteranceId: String) {
+                    onSpeakDone()
+                }
+
+                @Deprecated("Deprecated in Java")
+                override fun onError(utteranceId: String) {
+                    onSpeakError(null)
+                }
+
+                override fun onError(utteranceId: String, errorCode: Int) {
+                    onSpeakError(errorCode.toString())
+                }
+            })
+            val languageResult = textToSpeech.setLanguage(ttsLocale)
             if (languageResult == TextToSpeech.LANG_MISSING_DATA ||
                 languageResult == TextToSpeech.LANG_NOT_SUPPORTED
             ) {
@@ -30,10 +55,31 @@ class TextToSpeechManager(
         onReadyChanged(isReady)
     }
 
+    fun updateConfig(languageTag: String, rate: Float, pitch: Float): Boolean {
+        ttsLocale = parseLocale(languageTag)
+        ttsRate = rate
+        ttsPitch = pitch
+        if (!isReady) {
+            return false
+        }
+        val languageResult = textToSpeech.setLanguage(ttsLocale)
+        if (languageResult == TextToSpeech.LANG_MISSING_DATA ||
+            languageResult == TextToSpeech.LANG_NOT_SUPPORTED
+        ) {
+            Log.w("TextToSpeech", "Configured language not supported: $languageTag")
+            return false
+        }
+        textToSpeech.setSpeechRate(ttsRate)
+        textToSpeech.setPitch(ttsPitch)
+        return true
+    }
+
     fun speak(text: String, utteranceId: String = UUID.randomUUID().toString()): Boolean {
         if (!isReady || text.isBlank()) {
             return false
         }
+        textToSpeech.setSpeechRate(ttsRate)
+        textToSpeech.setPitch(ttsPitch)
         textToSpeech.speak(text, TextToSpeech.QUEUE_FLUSH, null, utteranceId)
         return true
     }
@@ -41,5 +87,20 @@ class TextToSpeechManager(
     fun shutdown() {
         textToSpeech.stop()
         textToSpeech.shutdown()
+    }
+
+    private fun parseLocale(languageTag: String): Locale {
+        val trimmed = languageTag.trim()
+        if (trimmed.isEmpty()) {
+            return Locale("es", "ES")
+        }
+        val normalized = trimmed.replace('_', '-')
+        val parts = normalized.split('-')
+        return when (parts.size) {
+            1 -> Locale(parts[0])
+            2 -> Locale(parts[0], parts[1])
+            3 -> Locale(parts[0], parts[1], parts[2])
+            else -> Locale.forLanguageTag(normalized)
+        }
     }
 }

--- a/app/src/main/res/layout-land/activity_main.xml
+++ b/app/src/main/res/layout-land/activity_main.xml
@@ -184,6 +184,65 @@
                 </LinearLayout>
             </com.google.android.material.card.MaterialCardView>
 
+            <com.google.android.material.card.MaterialCardView
+                android:id="@+id/summaryCard"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="16dp"
+                app:cardElevation="2dp"
+                app:cardCornerRadius="16dp"
+                app:strokeWidth="0dp"
+                android:stateListAnimator="@animator/card_state_list_anim"
+                app:layout_constraintTop_toBottomOf="@id/screenshotCard"
+                app:layout_constraintBottom_toTopOf="@id/commandHistoryCard">
+
+                <LinearLayout
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:orientation="vertical"
+                    android:padding="16dp">
+
+                    <LinearLayout
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:orientation="horizontal"
+                        android:gravity="center_vertical">
+
+                        <TextView
+                            android:layout_width="0dp"
+                            android:layout_height="wrap_content"
+                            android:layout_weight="1"
+                            android:text="@string/screen_summary_title"
+                            android:textAppearance="?attr/textAppearanceTitleMedium" />
+
+                        <com.google.android.material.button.MaterialButton
+                            android:id="@+id/btnPlaySummary"
+                            style="@style/Widget.Material3.Button.TextButton"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:text="@string/play_summary" />
+                    </LinearLayout>
+
+                    <TextView
+                        android:id="@+id/summaryText"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:layout_marginTop="8dp"
+                        android:text="@string/summary_unavailable"
+                        android:textAppearance="?attr/textAppearanceBodyMedium" />
+
+                    <TextView
+                        android:id="@+id/summaryStatusText"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:layout_marginTop="6dp"
+                        android:text="@string/summary_status_empty"
+                        android:textAppearance="?attr/textAppearanceBodySmall"
+                        android:textStyle="italic" />
+
+                </LinearLayout>
+            </com.google.android.material.card.MaterialCardView>
+
             <!-- Command History Card -->
             <com.google.android.material.card.MaterialCardView
                 android:id="@+id/commandHistoryCard"
@@ -194,7 +253,7 @@
                 app:cardCornerRadius="16dp"
                 app:strokeWidth="0dp"
                 android:stateListAnimator="@animator/card_state_list_anim"
-                app:layout_constraintTop_toBottomOf="@id/screenshotCard"
+                app:layout_constraintTop_toBottomOf="@id/summaryCard"
                 app:layout_constraintBottom_toTopOf="@id/favoritesCard">
 
                 <LinearLayout
@@ -626,6 +685,57 @@
                                 android:inputType="number"
                                 android:maxLines="1"
                                 android:text="20" />
+                        </com.google.android.material.textfield.TextInputLayout>
+
+                        <com.google.android.material.textfield.TextInputLayout
+                            android:id="@+id/ttsLanguageLayout"
+                            style="@style/Widget.MaterialComponents.TextInputLayout.OutlinedBox"
+                            android:layout_width="match_parent"
+                            android:layout_height="wrap_content"
+                            android:layout_marginTop="8dp"
+                            android:hint="@string/tts_language_hint">
+
+                            <com.google.android.material.textfield.TextInputEditText
+                                android:id="@+id/ttsLanguageInput"
+                                android:layout_width="match_parent"
+                                android:layout_height="wrap_content"
+                                android:inputType="text"
+                                android:maxLines="1"
+                                android:text="es-ES" />
+                        </com.google.android.material.textfield.TextInputLayout>
+
+                        <com.google.android.material.textfield.TextInputLayout
+                            android:id="@+id/ttsRateLayout"
+                            style="@style/Widget.MaterialComponents.TextInputLayout.OutlinedBox"
+                            android:layout_width="match_parent"
+                            android:layout_height="wrap_content"
+                            android:layout_marginTop="8dp"
+                            android:hint="@string/tts_rate_hint">
+
+                            <com.google.android.material.textfield.TextInputEditText
+                                android:id="@+id/ttsRateInput"
+                                android:layout_width="match_parent"
+                                android:layout_height="wrap_content"
+                                android:inputType="numberDecimal"
+                                android:maxLines="1"
+                                android:text="1.0" />
+                        </com.google.android.material.textfield.TextInputLayout>
+
+                        <com.google.android.material.textfield.TextInputLayout
+                            android:id="@+id/ttsPitchLayout"
+                            style="@style/Widget.MaterialComponents.TextInputLayout.OutlinedBox"
+                            android:layout_width="match_parent"
+                            android:layout_height="wrap_content"
+                            android:layout_marginTop="8dp"
+                            android:hint="@string/tts_pitch_hint">
+
+                            <com.google.android.material.textfield.TextInputEditText
+                                android:id="@+id/ttsPitchInput"
+                                android:layout_width="match_parent"
+                                android:layout_height="wrap_content"
+                                android:inputType="numberDecimal"
+                                android:maxLines="1"
+                                android:text="1.0" />
                         </com.google.android.material.textfield.TextInputLayout>
 
                         <!-- Test Connection Button -->

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -181,6 +181,56 @@
                 </LinearLayout>
             </com.google.android.material.card.MaterialCardView>
 
+            <com.google.android.material.card.MaterialCardView
+                android:id="@+id/summaryCard"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="16dp"
+                app:cardElevation="2dp"
+                app:cardCornerRadius="16dp"
+                app:strokeWidth="0dp"
+                android:stateListAnimator="@animator/card_state_list_anim"
+                app:layout_constraintTop_toBottomOf="@id/screenshotCard"
+                app:layout_constraintBottom_toTopOf="@id/commandHistoryCard">
+
+                <LinearLayout
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:orientation="vertical"
+                    android:padding="16dp">
+
+                    <LinearLayout
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:orientation="horizontal"
+                        android:gravity="center_vertical">
+
+                        <TextView
+                            android:layout_width="0dp"
+                            android:layout_height="wrap_content"
+                            android:layout_weight="1"
+                            android:text="@string/screen_summary_title"
+                            android:textAppearance="?attr/textAppearanceTitleMedium" />
+
+                        <com.google.android.material.button.MaterialButton
+                            android:id="@+id/btnPlaySummary"
+                            style="@style/Widget.Material3.Button.TextButton"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:text="@string/play_summary" />
+                    </LinearLayout>
+
+                    <TextView
+                        android:id="@+id/summaryText"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:layout_marginTop="8dp"
+                        android:text="@string/summary_unavailable"
+                        android:textAppearance="?attr/textAppearanceBodyMedium" />
+
+                </LinearLayout>
+            </com.google.android.material.card.MaterialCardView>
+
             <!-- Command History Card -->
             <com.google.android.material.card.MaterialCardView
                 android:id="@+id/commandHistoryCard"
@@ -191,7 +241,7 @@
                 app:cardCornerRadius="16dp"
                 app:strokeWidth="0dp"
                 android:stateListAnimator="@animator/card_state_list_anim"
-                app:layout_constraintTop_toBottomOf="@id/screenshotCard"
+                app:layout_constraintTop_toBottomOf="@id/summaryCard"
                 app:layout_constraintBottom_toTopOf="@id/favoritesCard">
 
                 <LinearLayout

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -228,6 +228,15 @@
                         android:text="@string/summary_unavailable"
                         android:textAppearance="?attr/textAppearanceBodyMedium" />
 
+                    <TextView
+                        android:id="@+id/summaryStatusText"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:layout_marginTop="6dp"
+                        android:text="@string/summary_status_empty"
+                        android:textAppearance="?attr/textAppearanceBodySmall"
+                        android:textStyle="italic" />
+
                 </LinearLayout>
             </com.google.android.material.card.MaterialCardView>
 
@@ -673,6 +682,57 @@
                                 android:inputType="number"
                                 android:maxLines="1"
                                 android:text="20" />
+                        </com.google.android.material.textfield.TextInputLayout>
+
+                        <com.google.android.material.textfield.TextInputLayout
+                            android:id="@+id/ttsLanguageLayout"
+                            style="@style/Widget.MaterialComponents.TextInputLayout.OutlinedBox"
+                            android:layout_width="match_parent"
+                            android:layout_height="wrap_content"
+                            android:layout_marginTop="8dp"
+                            android:hint="@string/tts_language_hint">
+
+                            <com.google.android.material.textfield.TextInputEditText
+                                android:id="@+id/ttsLanguageInput"
+                                android:layout_width="match_parent"
+                                android:layout_height="wrap_content"
+                                android:inputType="text"
+                                android:maxLines="1"
+                                android:text="es-ES" />
+                        </com.google.android.material.textfield.TextInputLayout>
+
+                        <com.google.android.material.textfield.TextInputLayout
+                            android:id="@+id/ttsRateLayout"
+                            style="@style/Widget.MaterialComponents.TextInputLayout.OutlinedBox"
+                            android:layout_width="match_parent"
+                            android:layout_height="wrap_content"
+                            android:layout_marginTop="8dp"
+                            android:hint="@string/tts_rate_hint">
+
+                            <com.google.android.material.textfield.TextInputEditText
+                                android:id="@+id/ttsRateInput"
+                                android:layout_width="match_parent"
+                                android:layout_height="wrap_content"
+                                android:inputType="numberDecimal"
+                                android:maxLines="1"
+                                android:text="1.0" />
+                        </com.google.android.material.textfield.TextInputLayout>
+
+                        <com.google.android.material.textfield.TextInputLayout
+                            android:id="@+id/ttsPitchLayout"
+                            style="@style/Widget.MaterialComponents.TextInputLayout.OutlinedBox"
+                            android:layout_width="match_parent"
+                            android:layout_height="wrap_content"
+                            android:layout_marginTop="8dp"
+                            android:hint="@string/tts_pitch_hint">
+
+                            <com.google.android.material.textfield.TextInputEditText
+                                android:id="@+id/ttsPitchInput"
+                                android:layout_width="match_parent"
+                                android:layout_height="wrap_content"
+                                android:inputType="numberDecimal"
+                                android:maxLines="1"
+                                android:text="1.0" />
                         </com.google.android.material.textfield.TextInputLayout>
 
                         <!-- Test Connection Button -->

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -83,6 +83,7 @@
     <string name="detected_language">Detected language: %1$s</string>
     <string name="steps_executed">Steps executed: %1$d</string>
     <string name="result">Result: %1$s</string>
+    <string name="screen_summary_label">Screen summary: %1$s</string>
     <string name="audio_response_available">Audio response available, requesting download...</string>
     <string name="error_processing_json">Error processing JSON response: %1$s</string>
     <string name="error_processing_response">Error processing response: %1$s</string>
@@ -136,6 +137,9 @@
     <string name="audio_permission_granted">Audio permission granted</string>
     <string name="audio_permission_denied">Audio permission denied</string>
     <string name="audio_permission_required">Audio recording permission is required for this functionality</string>
+    <string name="screen_summary_title">Resumen</string>
+    <string name="summary_unavailable">Sin resumen disponible</string>
+    <string name="play_summary">Reproducir</string>
 
     <!-- MainActivity Messages -->
     <string name="recording_finished_processing">Recording finished, processing...</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -88,7 +88,10 @@
     <string name="error_processing_response">Error processing response: %1$s</string>
     <string name="test_mode_tts">TEST MODE: Simulating text-to-speech response</string>
     <string name="test_mode_tts_ready">TEST MODE: Simulated TTS response ready</string>
-    <string name="would_generate_tts">Would generate TTS response for: \"%1$s\"</string>
+    <string name="tts_initialized">Text-to-Speech ready</string>
+    <string name="tts_init_failed">Text-to-Speech unavailable</string>
+    <string name="tts_speaking_response">Speaking response with Text-to-Speech</string>
+    <string name="tts_not_ready">Text-to-Speech not ready to speak</string>
     <string name="playing_audio_response">Playing audio response</string>
     <string name="trying_to_play">Trying to play response from: %1$s</string>
     <string name="no_previous_response">No previous response saved. File does not exist.</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -17,6 +17,9 @@
     <string name="server_port_hint">Server Port</string>
     <string name="unlock_password_hint">Unlock Password</string>
     <string name="response_timeout_hint">Response Timeout (seconds)</string>
+    <string name="tts_language_hint">TTS Language (e.g. es-ES)</string>
+    <string name="tts_rate_hint">TTS Speed (0.1 - 2.0)</string>
+    <string name="tts_pitch_hint">TTS Pitch (0.1 - 2.0)</string>
     <string name="test_connection">Test Connection</string>
     <string name="whisper_model_hint">Whisper Model Size</string>
     <string name="whisper_model_help">More accurate models require more resources:\n• tiny: ~39M parameters (~75 MB) - Very fast, less accurate\n• base: ~74M parameters (~142 MB) - Balanced (default)\n• small: ~244M parameters (~466 MB) - Good accuracy and speed\n• medium: ~769M parameters (~1.5 GB) - More accurate, slower\n• large: ~1550M parameters (~2.9 GB) - Maximum accuracy</string>
@@ -93,6 +96,7 @@
     <string name="tts_init_failed">Text-to-Speech unavailable</string>
     <string name="tts_speaking_response">Speaking response with Text-to-Speech</string>
     <string name="tts_not_ready">Text-to-Speech not ready to speak</string>
+    <string name="tts_config_failed">Text-to-Speech configuration failed for %1$s</string>
     <string name="playing_audio_response">Playing audio response</string>
     <string name="trying_to_play">Trying to play response from: %1$s</string>
     <string name="no_previous_response">No previous response saved. File does not exist.</string>
@@ -140,6 +144,10 @@
     <string name="screen_summary_title">Resumen</string>
     <string name="summary_unavailable">Sin resumen disponible</string>
     <string name="play_summary">Reproducir</string>
+    <string name="summary_status_ready">Listo para reproducir</string>
+    <string name="summary_status_playing">Reproduciendo</string>
+    <string name="summary_status_error">Error al reproducir</string>
+    <string name="summary_status_empty">Esperando resumen</string>
 
     <!-- MainActivity Messages -->
     <string name="recording_finished_processing">Recording finished, processing...</string>
@@ -216,6 +224,9 @@
     <string name="empty_server_port_error">Server port cannot be empty</string>
     <string name="invalid_port_error">Port must be a valid number</string>
     <string name="invalid_timeout_error">Timeout must be between 5 and 120 seconds</string>
+    <string name="invalid_tts_language_error">Invalid TTS language</string>
+    <string name="invalid_tts_rate_error">TTS speed must be between 0.1 and 2.0</string>
+    <string name="invalid_tts_pitch_error">TTS pitch must be between 0.1 and 2.0</string>
     <string name="empty_whisper_model_error">You must select a Whisper model</string>
     <string name="settings_saved">Settings saved</string>
     <string name="last_capture">Last capture: %1$s</string>


### PR DESCRIPTION
### Motivation
- Avoid calling Android `TextToSpeech` from a background thread which can cause failures or undefined behavior. 
- Provide native TTS playback for server responses when no audio file is returned. 
- Surface TTS initialization and playback state to the app logs and UI strings. 

### Description
- Add `TextToSpeechManager.kt` implementing lifecycle-safe `TextToSpeech` initialization, `speak(...)`, and `shutdown()` methods. 
- Instantiate `TextToSpeechManager` in `AudioService.onCreate()` and call `shutdown()` in `onDestroy()`. 
- Dispatch TTS playback to the main thread by wrapping the `speak(...)` call in `serviceScope.launch(Dispatchers.Main)` inside `createTextToSpeechResponse(...)`. 
- Add new user-facing strings for TTS state and document TTS behavior in `README.md`. 

### Testing
- Attempted an automated build with `./gradlew build`, which failed due to missing Android SDK configuration (`ANDROID_HOME` or `local.properties` with `sdk.dir`).
- No other automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694d14a675c0832591dc8c074870987f)