### PR TITLE
Add Telegram MCP connector for sending local files via sendDocument

### DIFF
--- a/mcp/README.md
+++ b/mcp/README.md
@@ -1,0 +1,74 @@
+# Telegram MCP connector
+
+Servidor MCP (STDIO) minimalista para que Cursor envíe archivos locales a un chat de Telegram usando `sendDocument`.
+
+## Requisitos
+
+- Python 3.10+
+- Bot de Telegram (token) y `chat_id`
+
+Instala dependencias:
+
+```bash
+python3 -m venv .venv
+. .venv/bin/activate
+pip install "mcp[cli]"
+```
+
+## Configurar Cursor
+
+Crea `.cursor/mcp.json` en la raíz del repo:
+
+```json
+{
+  "mcpServers": {
+    "telegram": {
+      "command": "/ABSOLUTE/PATH/TO/PROJECT/.venv/bin/python",
+      "args": ["/ABSOLUTE/PATH/TO/PROJECT/mcp/telegram_mcp.py"],
+      "env": {
+        "TELEGRAM_BOT_TOKEN": "YOUR_BOT_TOKEN",
+        "TELEGRAM_CHAT_ID": "YOUR_CHAT_ID",
+        "TELEGRAM_ALLOWED_ROOT": "/ABSOLUTE/PATH/TO/PROJECT"
+      }
+    }
+  }
+}
+```
+
+Si tu Cursor/OS no soporta `env` en `mcp.json`, usa un wrapper:
+
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+export TELEGRAM_BOT_TOKEN="YOUR_BOT_TOKEN"
+export TELEGRAM_CHAT_ID="YOUR_CHAT_ID"
+exec /ABSOLUTE/PATH/TO/PROJECT/.venv/bin/python /ABSOLUTE/PATH/TO/PROJECT/mcp/telegram_mcp.py
+```
+
+Y en `.cursor/mcp.json`:
+
+```json
+{
+  "mcpServers": {
+    "telegram": {
+      "command": "bash",
+      "args": ["/ABSOLUTE/PATH/TO/PROJECT/run_telegram_mcp.sh"]
+    }
+  }
+}
+```
+
+## Uso en Cursor
+
+Ejemplo:
+
+> Usa `send_document` para enviar `./ruta/al/archivo.pdf` a Telegram con caption `build artifacts`.
+
+Tool expuesta: `send_document(file_path, caption?, chat_id?, disable_notification?, protect_content?)`.
+
+## Variables de entorno
+
+- `TELEGRAM_BOT_TOKEN`: token del bot.
+- `TELEGRAM_CHAT_ID`: chat destino por defecto.
+- `TELEGRAM_ALLOWED_ROOT`: raíz opcional para restringir rutas.
+- `TELEGRAM_API_HOST`: host opcional, por defecto `api.telegram.org`.

--- a/mcp/telegram_mcp.py
+++ b/mcp/telegram_mcp.py
@@ -1,0 +1,196 @@
+#!/usr/bin/env python3
+import asyncio
+import json
+import logging
+import os
+import pathlib
+import sys
+import uuid
+import http.client
+from typing import Optional
+
+from mcp.server.fastmcp import FastMCP
+
+# IMPORTANT: no stdout logs in STDIO servers
+logging.basicConfig(stream=sys.stderr, level=logging.INFO)
+log = logging.getLogger("telegram_mcp")
+
+mcp = FastMCP("telegram")
+
+TELEGRAM_API_HOST = os.getenv("TELEGRAM_API_HOST", "api.telegram.org")
+TELEGRAM_BOT_TOKEN = os.getenv("TELEGRAM_BOT_TOKEN", "")
+TELEGRAM_CHAT_ID_DEFAULT = os.getenv("TELEGRAM_CHAT_ID", "")
+ALLOWED_ROOT = os.getenv("TELEGRAM_ALLOWED_ROOT", "").strip()
+
+CHUNK_SIZE = 1024 * 1024  # 1 MiB
+
+
+def _ensure_allowed(path: pathlib.Path) -> None:
+    if not ALLOWED_ROOT:
+        return
+    root = pathlib.Path(ALLOWED_ROOT).expanduser().resolve()
+    resolved = path.expanduser().resolve()
+    try:
+        resolved.relative_to(root)
+    except Exception as exc:
+        raise ValueError(
+            f"Path fuera de TELEGRAM_ALLOWED_ROOT: {resolved} (root={root})"
+        ) from exc
+
+
+def _multipart_lengths(
+    boundary: str,
+    fields: list[tuple[str, str]],
+    file_field: str,
+    filename: str,
+) -> tuple[bytes, bytes]:
+    b = boundary.encode()
+
+    parts = []
+    for key, value in fields:
+        parts.append(
+            b"--" + b + b"\r\n"
+            + f'Content-Disposition: form-data; name="{key}"\r\n\r\n'.encode()
+            + value.encode("utf-8")
+            + b"\r\n"
+        )
+
+    file_header = (
+        b"--" + b + b"\r\n"
+        + (
+            f'Content-Disposition: form-data; name="{file_field}"; '
+            f'filename="{filename}"\r\n'
+        ).encode()
+        + b"Content-Type: application/octet-stream\r\n\r\n"
+    )
+    closing = b"\r\n--" + b + b"--\r\n"
+
+    prefix = b"".join(parts) + file_header
+    suffix = closing
+    return prefix, suffix
+
+
+def _telegram_send_document_sync(
+    token: str,
+    chat_id: str,
+    file_path: str,
+    caption: Optional[str] = None,
+    disable_notification: bool = False,
+    protect_content: bool = False,
+) -> dict:
+    if not token:
+        raise ValueError("Falta TELEGRAM_BOT_TOKEN (env) o token (param).")
+    if not chat_id:
+        raise ValueError("Falta TELEGRAM_CHAT_ID (env) o chat_id (param).")
+
+    path = pathlib.Path(file_path).expanduser()
+    if not path.exists() or not path.is_file():
+        raise FileNotFoundError(f"No existe el archivo: {path}")
+
+    _ensure_allowed(path)
+
+    boundary = "mcp-" + uuid.uuid4().hex
+    filename = path.name
+
+    fields = [("chat_id", str(chat_id))]
+    if caption:
+        fields.append(("caption", caption))
+    if disable_notification:
+        fields.append(("disable_notification", "true"))
+    if protect_content:
+        fields.append(("protect_content", "true"))
+
+    prefix, suffix = _multipart_lengths(boundary, fields, "document", filename)
+    file_size = path.stat().st_size
+    content_length = len(prefix) + file_size + len(suffix)
+
+    conn = http.client.HTTPSConnection(TELEGRAM_API_HOST, timeout=120)
+    endpoint = f"/bot{token}/sendDocument"
+
+    conn.putrequest("POST", endpoint)
+    conn.putheader("Content-Type", f"multipart/form-data; boundary={boundary}")
+    conn.putheader("Content-Length", str(content_length))
+    conn.endheaders()
+
+    conn.send(prefix)
+    with path.open("rb") as file_handle:
+        while True:
+            chunk = file_handle.read(CHUNK_SIZE)
+            if not chunk:
+                break
+            conn.send(chunk)
+    conn.send(suffix)
+
+    response = conn.getresponse()
+    body = response.read()
+    conn.close()
+
+    try:
+        data = json.loads(body.decode("utf-8", errors="replace"))
+    except Exception as exc:
+        raise RuntimeError(
+            "Respuesta no-JSON de Telegram: "
+            f"HTTP {response.status} {response.reason}: {body[:200]!r}"
+        ) from exc
+
+    if response.status < 200 or response.status >= 300 or not data.get("ok"):
+        raise RuntimeError(
+            f"Telegram error: HTTP {response.status} {response.reason}: {data}"
+        )
+
+    return data
+
+
+@mcp.tool()
+async def send_document(
+    file_path: str,
+    caption: Optional[str] = None,
+    chat_id: Optional[str] = None,
+    disable_notification: bool = False,
+    protect_content: bool = False,
+) -> str:
+    """
+    Envía un archivo local a un chat de Telegram vía Bot API (sendDocument).
+
+    Args:
+      file_path: Ruta local al archivo (absoluta o relativa).
+      caption: Texto opcional (0-1024 chars en Telegram).
+      chat_id: Si se omite, usa TELEGRAM_CHAT_ID (env).
+      disable_notification: Envío silencioso.
+      protect_content: Evita reenvío/guardado (si aplica).
+
+    Returns:
+      Resumen con message_id y nombre de archivo.
+    """
+    token = TELEGRAM_BOT_TOKEN
+    resolved_chat_id = chat_id or TELEGRAM_CHAT_ID_DEFAULT
+
+    data = await asyncio.to_thread(
+        _telegram_send_document_sync,
+        token,
+        resolved_chat_id,
+        file_path,
+        caption,
+        disable_notification,
+        protect_content,
+    )
+
+    msg = data.get("result", {})
+    message_id = msg.get("message_id")
+    document = msg.get("document", {}) or {}
+    sent_name = document.get("file_name") or pathlib.Path(file_path).name
+    sent_size = document.get("file_size")
+
+    return (
+        "Enviado a Telegram. "
+        f"message_id={message_id}, file_name={sent_name}, file_size={sent_size}"
+    )
+
+
+def main() -> None:
+    # IMPORTANT: do not print to stdout
+    mcp.run(transport="stdio")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
### Motivation
- Provide a lightweight MCP (STDIO) server so Cursor can send local files to a Telegram chat using the Bot API `sendDocument` method.
- Avoid large dependencies and keep the connector minimal and suitable to run from a project virtualenv with `mcp[cli]`.
- Restrict file access via an optional root (`TELEGRAM_ALLOWED_ROOT`) to reduce accidental exfiltration of arbitrary files.
- Stream file uploads to handle larger files efficiently and avoid loading whole files into memory.

### Description
- Add `mcp/telegram_mcp.py`, a FastMCP server exposing the `send_document` tool that sends a local file with `http.client` multipart streaming and `asyncio.to_thread` for blocking IO.
- Implement boundary-aware multipart prefix/suffix calculation in `_multipart_lengths` and stream the file in `CHUNK_SIZE` (1 MiB) chunks to the Telegram API endpoint `/bot{token}/sendDocument`.
- Add path safety via `_ensure_allowed` which enforces `TELEGRAM_ALLOWED_ROOT` when set, and avoid printing to stdout by logging to `stderr` only.
- Add `mcp/README.md` documenting setup, required env vars (`TELEGRAM_BOT_TOKEN`, `TELEGRAM_CHAT_ID`, `TELEGRAM_ALLOWED_ROOT`, `TELEGRAM_API_HOST`), and example `.cursor/mcp.json` plus an optional wrapper script.

### Testing
- No automated tests were run against the new files during this change.
- Manual repository operations (`git add`/`git commit`) succeeded as part of the change preparation but are not automated tests.
- Functional verification is expected to be performed by running the connector with valid `TELEGRAM_BOT_TOKEN` and `TELEGRAM_CHAT_ID` in a local environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694dce09941083258651984506a3531a)