### PR TITLE
Add audio playback toggle to Settings and enforce preference in AudioService

### DIFF
--- a/app/src/main/java/com/example/myapplication/SettingsActivity.kt
+++ b/app/src/main/java/com/example/myapplication/SettingsActivity.kt
@@ -22,6 +22,7 @@ import com.example.myapplication.AudioService.Companion.KEY_TTS_RATE
 import com.example.myapplication.AudioService.Companion.KEY_WHISPER_MODEL
 import com.google.android.material.appbar.MaterialToolbar
 import com.google.android.material.button.MaterialButton
+import com.google.android.material.switchmaterial.SwitchMaterial
 import com.google.android.material.textfield.TextInputEditText
 
 class SettingsActivity : AppCompatActivity() {
@@ -33,6 +34,7 @@ class SettingsActivity : AppCompatActivity() {
     private lateinit var ttsLanguageInput: TextInputEditText
     private lateinit var ttsRateInput: TextInputEditText
     private lateinit var ttsPitchInput: TextInputEditText
+    private lateinit var audioPlaybackSwitch: SwitchMaterial
     private lateinit var btnTestConnection: MaterialButton
     private lateinit var btnSaveSettings: MaterialButton
     private lateinit var connectionStatusText: TextView
@@ -98,6 +100,7 @@ class SettingsActivity : AppCompatActivity() {
         ttsLanguageInput = findViewById(R.id.ttsLanguageInput)
         ttsRateInput = findViewById(R.id.ttsRateInput)
         ttsPitchInput = findViewById(R.id.ttsPitchInput)
+        audioPlaybackSwitch = findViewById(R.id.audioPlaybackSwitch)
         btnTestConnection = findViewById(R.id.btnTestConnection)
         btnSaveSettings = findViewById(R.id.btnSaveSettings)
         connectionStatusText = findViewById(R.id.connectionStatusText)
@@ -127,6 +130,10 @@ class SettingsActivity : AppCompatActivity() {
 
         btnTestConnection.setOnClickListener {
             testServerConnection()
+        }
+
+        audioPlaybackSwitch.setOnCheckedChangeListener { _, isChecked ->
+            updateAudioPlaybackSwitchText(isChecked)
         }
     }
 
@@ -186,6 +193,10 @@ class SettingsActivity : AppCompatActivity() {
             ?: AudioService.DEFAULT_TTS_LANGUAGE
         val ttsRate = prefs.getFloat(KEY_TTS_RATE, AudioService.DEFAULT_TTS_RATE)
         val ttsPitch = prefs.getFloat(KEY_TTS_PITCH, AudioService.DEFAULT_TTS_PITCH)
+        val audioPlaybackEnabled = prefs.getBoolean(
+            AudioService.KEY_AUDIO_PLAYBACK_ENABLED,
+            AudioService.DEFAULT_AUDIO_PLAYBACK_ENABLED
+        )
 
         serverIpInput.setText(serverIp)
         serverPortInput.setText(serverPort.toString())
@@ -195,6 +206,8 @@ class SettingsActivity : AppCompatActivity() {
         ttsLanguageInput.setText(ttsLanguage)
         ttsRateInput.setText(ttsRate.toString())
         ttsPitchInput.setText(ttsPitch.toString())
+        audioPlaybackSwitch.isChecked = audioPlaybackEnabled
+        updateAudioPlaybackSwitchText(audioPlaybackEnabled)
     }
 
     private fun saveServerSettings() {
@@ -206,6 +219,7 @@ class SettingsActivity : AppCompatActivity() {
         val ttsLanguage = ttsLanguageInput.text.toString().trim()
         val ttsRateText = ttsRateInput.text.toString().trim()
         val ttsPitchText = ttsPitchInput.text.toString().trim()
+        val audioPlaybackEnabled = audioPlaybackSwitch.isChecked
 
         if (ip.isEmpty()) {
             Toast.makeText(this, getString(R.string.empty_server_ip_error), Toast.LENGTH_SHORT).show()
@@ -280,6 +294,7 @@ class SettingsActivity : AppCompatActivity() {
             putString(KEY_TTS_LANGUAGE, ttsLanguage)
             putFloat(KEY_TTS_RATE, rate)
             putFloat(KEY_TTS_PITCH, pitch)
+            putBoolean(AudioService.KEY_AUDIO_PLAYBACK_ENABLED, audioPlaybackEnabled)
             commit()
         }
 
@@ -292,6 +307,7 @@ class SettingsActivity : AppCompatActivity() {
             putExtra(KEY_TTS_LANGUAGE, ttsLanguage)
             putExtra(KEY_TTS_RATE, rate)
             putExtra(KEY_TTS_PITCH, pitch)
+            putExtra(AudioService.KEY_AUDIO_PLAYBACK_ENABLED, audioPlaybackEnabled)
         }
         startService(intent)
 
@@ -338,6 +354,12 @@ class SettingsActivity : AppCompatActivity() {
                 )
             )
         }
+    }
+
+    private fun updateAudioPlaybackSwitchText(enabled: Boolean) {
+        audioPlaybackSwitch.text = getString(
+            if (enabled) R.string.audio_playback_enabled else R.string.audio_playback_disabled
+        )
     }
 
     companion object {

--- a/app/src/main/res/layout/activity_settings.xml
+++ b/app/src/main/res/layout/activity_settings.xml
@@ -185,6 +185,14 @@
                             android:maxLines="1" />
                     </com.google.android.material.textfield.TextInputLayout>
 
+                    <com.google.android.material.switchmaterial.SwitchMaterial
+                        android:id="@+id/audioPlaybackSwitch"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:layout_marginTop="16dp"
+                        android:checked="true"
+                        android:text="@string/audio_playback_enabled" />
+
                     <LinearLayout
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -173,6 +173,8 @@
     <string name="server_configuration_updated">Server configuration updated</string>
     <string name="forced_reset_recording_state">Forced reset of recording state</string>
     <string name="audio_service_stopped">Audio service stopped</string>
+    <string name="audio_playback_enabled">Audio playback enabled</string>
+    <string name="audio_playback_disabled">Audio playback disabled</string>
     <string name="error_starting_recording">Error starting recording</string>
     <string name="error_unexpected_starting_recording">Unexpected error while starting recording</string>
     <string name="no_recording_in_progress_for_cancel">No recording in progress to cancel</string>


### PR DESCRIPTION
### Motivation
- Provide a user-facing control to enable/disable automatic audio playback / TTS from the advanced Settings UI. 
- Keep the default behavior enabled while allowing users to persist their preference. 
- Ensure the running audio service reads and honors the saved preference so audio/TTS can be globally suppressed.

### Description
- Add a `SwitchMaterial` (`@+id/audioPlaybackSwitch`) to `activity_settings.xml` and strings `audio_playback_enabled` / `audio_playback_disabled`.
- Extend `SettingsActivity` to initialize the switch, read/write the `AudioService.KEY_AUDIO_PLAYBACK_ENABLED` preference, update the switch label, and include `KEY_AUDIO_PLAYBACK_ENABLED` in the `UPDATE_SETTINGS` intent.
- Add `DEFAULT_AUDIO_PLAYBACK_ENABLED`, `KEY_AUDIO_PLAYBACK_ENABLED`, and an `audioPlaybackEnabled` field to `AudioService`, load/save it from `SharedPreferences`, accept the value in `onStartCommand` and `updateServerSettings`, and persist it.
- Guard audio/TTS entry points (`createTextToSpeechResponse`, `playAudioResponse`, `playLastResponse`, `playDownloadedAudio`) to no-op and log when `audioPlaybackEnabled` is `false`.

### Testing
- No automated tests were executed as part of this change.
- Manual verification steps were prepared (UI switch toggles state, preference persisted, service skips playback when disabled) but not run automatically.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694dd038960c83259b2cd5a1d1dbf360)