### PR TITLE
Añadir pantalla Capturas y cabecera en el cajón

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -53,6 +53,7 @@ dependencies {
     implementation(libs.material)
     implementation(libs.androidx.activity)
     implementation(libs.androidx.constraintlayout)
+    implementation("androidx.swiperefreshlayout:swiperefreshlayout:1.1.0")
     testImplementation(libs.junit)
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.espresso.core)

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -35,6 +35,10 @@
             android:name=".SettingsActivity"
             android:exported="false"
             android:label="@string/settings_title" />
+        <activity
+            android:name=".CapturesActivity"
+            android:exported="false"
+            android:label="@string/captures_title" />
 
         <!-- Servicio de audio en primer plano -->
         <service

--- a/app/src/main/java/com/example/myapplication/CapturesActivity.kt
+++ b/app/src/main/java/com/example/myapplication/CapturesActivity.kt
@@ -1,0 +1,284 @@
+package com.example.myapplication
+
+import android.content.Context
+import android.graphics.Bitmap
+import android.graphics.BitmapFactory
+import android.os.Bundle
+import android.util.LruCache
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.ImageView
+import android.widget.ProgressBar
+import android.widget.TextView
+import android.widget.Toast
+import androidx.appcompat.app.AppCompatActivity
+import androidx.recyclerview.widget.LinearLayoutManager
+import androidx.recyclerview.widget.RecyclerView
+import androidx.swiperefreshlayout.widget.SwipeRefreshLayout
+import com.example.myapplication.AudioService.Companion.KEY_SERVER_IP
+import com.example.myapplication.AudioService.Companion.KEY_SERVER_PORT
+import com.google.android.material.appbar.MaterialToolbar
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import org.json.JSONObject
+import java.time.Instant
+import java.time.LocalDateTime
+import java.time.ZoneId
+import java.time.format.DateTimeFormatter
+
+class CapturesActivity : AppCompatActivity() {
+    private lateinit var toolbar: MaterialToolbar
+    private lateinit var swipeRefresh: SwipeRefreshLayout
+    private lateinit var recyclerView: RecyclerView
+    private lateinit var emptyText: TextView
+    private lateinit var loadingProgress: ProgressBar
+
+    private val okHttpClient = OkHttpClient()
+    private val uiScope = CoroutineScope(Dispatchers.Main + SupervisorJob())
+
+    private val bitmapCache = object : LruCache<String, Bitmap>((Runtime.getRuntime().maxMemory() / 1024).toInt() / 8) {
+        override fun sizeOf(key: String, value: Bitmap): Int {
+            return value.byteCount / 1024
+        }
+    }
+
+    private val captureAdapter = CapturesAdapter(::loadCaptureInto)
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(R.layout.activity_captures)
+
+        toolbar = findViewById(R.id.capturesToolbar)
+        swipeRefresh = findViewById(R.id.capturesSwipeRefresh)
+        recyclerView = findViewById(R.id.capturesRecyclerView)
+        emptyText = findViewById(R.id.capturesEmptyText)
+        loadingProgress = findViewById(R.id.capturesLoadingProgress)
+
+        setSupportActionBar(toolbar)
+        toolbar.setNavigationOnClickListener { finish() }
+
+        recyclerView.layoutManager = LinearLayoutManager(this)
+        recyclerView.adapter = captureAdapter
+
+        swipeRefresh.setOnRefreshListener { fetchCaptures() }
+
+        fetchCaptures()
+    }
+
+    override fun onDestroy() {
+        super.onDestroy()
+        uiScope.cancel()
+    }
+
+    private fun fetchCaptures() {
+        showLoadingState()
+        swipeRefresh.isRefreshing = true
+        uiScope.launch {
+            val result = withContext(Dispatchers.IO) {
+                runCatching { requestCaptures() }
+            }
+            swipeRefresh.isRefreshing = false
+            result.onSuccess { items ->
+                updateCaptureList(items)
+            }.onFailure { error ->
+                showError(error)
+            }
+        }
+    }
+
+    private fun requestCaptures(): List<ScreenshotItem> {
+        val serverUrl = getServerUrl()
+        val request = Request.Builder()
+            .url("$serverUrl/screenshots/latest?limit=10")
+            .build()
+
+        okHttpClient.newCall(request).execute().use { response ->
+            if (!response.isSuccessful) {
+                throw IllegalStateException("HTTP ${response.code}")
+            }
+            val responseBody = response.body?.string().orEmpty()
+            if (responseBody.isBlank()) {
+                return emptyList()
+            }
+
+            val json = JSONObject(responseBody)
+            if (!json.has("screenshots")) {
+                return emptyList()
+            }
+
+            val screenshotsArray = json.getJSONArray("screenshots")
+            val items = mutableListOf<ScreenshotItem>()
+            for (index in 0 until screenshotsArray.length()) {
+                val entry = screenshotsArray.get(index)
+                when (entry) {
+                    is String -> {
+                        val parsedMillis = parseTimestampMillis(entry)
+                        items.add(createItem(entry, parsedMillis, index))
+                    }
+                    is JSONObject -> {
+                        val filename = entry.optString("filename", entry.optString("name", ""))
+                        if (filename.isBlank()) {
+                            continue
+                        }
+                        val parsedMillis = parseTimestampMillis(filename)
+                        val timestampMillis = entry.optLong("timestamp", 0L).takeIf { it > 0L }
+                            ?.let { normalizeTimestamp(it) }
+                            ?: parsedMillis
+                        items.add(createItem(filename, timestampMillis, index))
+                    }
+                }
+            }
+            return items.sortedWith(
+                compareByDescending<ScreenshotItem> { it.timestampMillis ?: Long.MIN_VALUE }
+                    .thenBy { it.originalIndex }
+            )
+        }
+    }
+
+    private fun createItem(filename: String, timestampMillis: Long?, index: Int): ScreenshotItem {
+        val displayTimestamp = timestampMillis?.let { formatTimestamp(it) }
+            ?: getString(R.string.timestamp_unavailable)
+        return ScreenshotItem(filename, timestampMillis, displayTimestamp, index)
+    }
+
+    private fun updateCaptureList(items: List<ScreenshotItem>) {
+        loadingProgress.visibility = View.GONE
+        emptyText.text = getString(R.string.captures_empty)
+        emptyText.visibility = if (items.isEmpty()) View.VISIBLE else View.GONE
+        captureAdapter.submit(items)
+    }
+
+    private fun showLoadingState() {
+        loadingProgress.visibility = View.VISIBLE
+        emptyText.text = getString(R.string.captures_loading)
+        emptyText.visibility = View.VISIBLE
+    }
+
+    private fun showError(error: Throwable) {
+        loadingProgress.visibility = View.GONE
+        emptyText.visibility = View.VISIBLE
+        emptyText.text = getString(R.string.captures_empty)
+        val message = error.message ?: getString(R.string.error_generic, \"\")
+        Toast.makeText(this, message, Toast.LENGTH_SHORT).show()
+    }
+
+    private fun loadCaptureInto(item: ScreenshotItem, imageView: ImageView, filenameView: TextView, timestampView: TextView) {
+        filenameView.text = item.filename
+        timestampView.text = item.displayTimestamp
+        imageView.contentDescription = getString(R.string.capture_image_description, item.displayTimestamp)
+        imageView.tag = item.filename
+        imageView.setImageBitmap(null)
+
+        val cached = bitmapCache.get(item.filename)
+        if (cached != null) {
+            imageView.setImageBitmap(cached)
+            return
+        }
+
+        uiScope.launch {
+            val bitmapResult = withContext(Dispatchers.IO) {
+                runCatching { fetchBitmap(item.filename) }
+            }
+            val bitmap = bitmapResult.getOrNull() ?: return@launch
+            bitmapCache.put(item.filename, bitmap)
+            if (imageView.tag == item.filename) {
+                imageView.setImageBitmap(bitmap)
+            }
+        }
+    }
+
+    private fun fetchBitmap(filename: String): Bitmap {
+        val serverUrl = getServerUrl()
+        val timestamp = System.currentTimeMillis()
+        val imageUrl = "$serverUrl/screenshots/$filename?t=$timestamp"
+        val request = Request.Builder().url(imageUrl).build()
+        okHttpClient.newCall(request).execute().use { response ->
+            if (!response.isSuccessful) {
+                throw IllegalStateException("HTTP ${response.code}")
+            }
+            val bytes = response.body?.bytes() ?: throw IllegalStateException("Empty body")
+            return BitmapFactory.decodeByteArray(bytes, 0, bytes.size)
+        }
+    }
+
+    private fun getServerUrl(): String {
+        val prefs = getSharedPreferences(AudioService.PREFS_NAME, Context.MODE_PRIVATE)
+        val serverIp = prefs.getString(KEY_SERVER_IP, AudioService.DEFAULT_SERVER_IP)
+            ?: AudioService.DEFAULT_SERVER_IP
+        val serverPort = prefs.getInt(KEY_SERVER_PORT, AudioService.DEFAULT_SERVER_PORT)
+        return "https://$serverIp:$serverPort"
+    }
+
+    private fun normalizeTimestamp(value: Long): Long {
+        return if (value > 1000000000000L) value else value * 1000
+    }
+
+    private fun formatTimestamp(timestampMillis: Long): String {
+        val instant = Instant.ofEpochMilli(timestampMillis)
+        val dateTime = LocalDateTime.ofInstant(instant, ZoneId.systemDefault())
+        return dateTime.format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss"))
+    }
+
+    private fun parseTimestampMillis(filename: String): Long? {
+        val match = FILENAME_TIMESTAMP_REGEX.find(filename) ?: return null
+        val (year, month, day, hour, minute, second) = match.destructured
+        val dateTime = LocalDateTime.of(
+            year.toInt(),
+            month.toInt(),
+            day.toInt(),
+            hour.toInt(),
+            minute.toInt(),
+            second.toInt()
+        )
+        return dateTime.atZone(ZoneId.systemDefault()).toInstant().toEpochMilli()
+    }
+
+    private class CapturesAdapter(
+        private val onBindImage: (ScreenshotItem, ImageView, TextView, TextView) -> Unit
+    ) : RecyclerView.Adapter<CapturesAdapter.CaptureViewHolder>() {
+
+        private var items: List<ScreenshotItem> = emptyList()
+
+        fun submit(newItems: List<ScreenshotItem>) {
+            items = newItems
+            notifyDataSetChanged()
+        }
+
+        override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): CaptureViewHolder {
+            val view = LayoutInflater.from(parent.context)
+                .inflate(R.layout.item_capture, parent, false)
+            return CaptureViewHolder(view)
+        }
+
+        override fun onBindViewHolder(holder: CaptureViewHolder, position: Int) {
+            val item = items[position]
+            onBindImage(item, holder.imageView, holder.filenameView, holder.timestampView)
+        }
+
+        override fun getItemCount(): Int = items.size
+
+        class CaptureViewHolder(itemView: View) : RecyclerView.ViewHolder(itemView) {
+            val imageView: ImageView = itemView.findViewById(R.id.captureImageView)
+            val timestampView: TextView = itemView.findViewById(R.id.captureTimestamp)
+            val filenameView: TextView = itemView.findViewById(R.id.captureFilename)
+        }
+    }
+
+    private data class ScreenshotItem(
+        val filename: String,
+        val timestampMillis: Long?,
+        val displayTimestamp: String,
+        val originalIndex: Int
+    )
+
+    companion object {
+        private val FILENAME_TIMESTAMP_REGEX = Regex("(\\d{4})[-_]?([01]\\d)[-_]?([0-3]\\d)[T_ -]?([0-2]\\d)[-_:]?([0-5]\\d)[-_:]?([0-5]\\d)")
+    }
+}

--- a/app/src/main/java/com/example/myapplication/MainActivity.kt
+++ b/app/src/main/java/com/example/myapplication/MainActivity.kt
@@ -403,6 +403,11 @@ class MainActivity : AppCompatActivity() {
         }
         navigationView.setNavigationItemSelectedListener { item ->
             when (item.itemId) {
+                R.id.nav_captures -> {
+                    startActivity(Intent(this, CapturesActivity::class.java))
+                    drawerLayout.closeDrawer(GravityCompat.START)
+                    true
+                }
                 R.id.nav_settings -> {
                     startActivity(Intent(this, SettingsActivity::class.java))
                     drawerLayout.closeDrawer(GravityCompat.START)

--- a/app/src/main/res/layout-land/activity_main.xml
+++ b/app/src/main/res/layout-land/activity_main.xml
@@ -617,6 +617,7 @@
         android:layout_height="match_parent"
         android:layout_gravity="start"
         android:fitsSystemWindows="true"
+        app:headerLayout="@layout/drawer_header"
         app:menu="@menu/drawer_menu" />
 
 </androidx.drawerlayout.widget.DrawerLayout>

--- a/app/src/main/res/layout/activity_captures.xml
+++ b/app/src/main/res/layout/activity_captures.xml
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.coordinatorlayout.widget.CoordinatorLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <com.google.android.material.appbar.AppBarLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content">
+
+        <com.google.android.material.appbar.MaterialToolbar
+            android:id="@+id/capturesToolbar"
+            android:layout_width="match_parent"
+            android:layout_height="?attr/actionBarSize"
+            android:background="@android:color/transparent"
+            app:navigationIcon="@android:drawable/ic_menu_close_clear_cancel"
+            app:title="@string/captures_title" />
+    </com.google.android.material.appbar.AppBarLayout>
+
+    <androidx.swiperefreshlayout.widget.SwipeRefreshLayout
+        android:id="@+id/capturesSwipeRefresh"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        app:layout_behavior="@string/appbar_scrolling_view_behavior">
+
+        <FrameLayout
+            android:layout_width="match_parent"
+            android:layout_height="match_parent">
+
+            <androidx.recyclerview.widget.RecyclerView
+                android:id="@+id/capturesRecyclerView"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                android:clipToPadding="false"
+                android:padding="16dp" />
+
+            <TextView
+                android:id="@+id/capturesEmptyText"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_gravity="center"
+                android:text="@string/captures_empty"
+                android:textAppearance="?attr/textAppearanceBodyLarge"
+                android:visibility="gone" />
+
+            <ProgressBar
+                android:id="@+id/capturesLoadingProgress"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_gravity="center" />
+        </FrameLayout>
+    </androidx.swiperefreshlayout.widget.SwipeRefreshLayout>
+</androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -625,6 +625,7 @@
         android:layout_height="match_parent"
         android:layout_gravity="start"
         android:fitsSystemWindows="true"
+        app:headerLayout="@layout/drawer_header"
         app:menu="@menu/drawer_menu" />
 
 </androidx.drawerlayout.widget.DrawerLayout>

--- a/app/src/main/res/layout/drawer_header.xml
+++ b/app/src/main/res/layout/drawer_header.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:orientation="vertical"
+    android:padding="20dp">
+
+    <ImageView
+        android:id="@+id/drawerAppIcon"
+        android:layout_width="48dp"
+        android:layout_height="48dp"
+        android:contentDescription="@string/app_name"
+        android:src="@mipmap/ic_launcher" />
+
+    <TextView
+        android:id="@+id/drawerAppName"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="12dp"
+        android:text="@string/app_name"
+        android:textAppearance="?attr/textAppearanceTitleMedium"
+        android:textStyle="bold" />
+</LinearLayout>

--- a/app/src/main/res/layout/item_capture.xml
+++ b/app/src/main/res/layout/item_capture.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="utf-8"?>
+<com.google.android.material.card.MaterialCardView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:layout_marginBottom="16dp"
+    app:cardCornerRadius="14dp"
+    app:cardElevation="2dp"
+    app:strokeWidth="0dp">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical">
+
+        <ImageView
+            android:id="@+id/captureImageView"
+            android:layout_width="match_parent"
+            android:layout_height="220dp"
+            android:adjustViewBounds="true"
+            android:background="@android:color/darker_gray"
+            android:contentDescription="@string/remote_screenshot"
+            android:scaleType="centerCrop" />
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="vertical"
+            android:padding="16dp">
+
+            <TextView
+                android:id="@+id/captureTimestamp"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:textAppearance="?attr/textAppearanceTitleSmall"
+                android:textColor="?android:textColorPrimary" />
+
+            <TextView
+                android:id="@+id/captureFilename"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="4dp"
+                android:textAppearance="?attr/textAppearanceBodySmall"
+                android:textColor="?android:textColorSecondary" />
+        </LinearLayout>
+    </LinearLayout>
+</com.google.android.material.card.MaterialCardView>

--- a/app/src/main/res/menu/drawer_menu.xml
+++ b/app/src/main/res/menu/drawer_menu.xml
@@ -1,6 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <menu xmlns:android="http://schemas.android.com/apk/res/android">
     <item
+        android:id="@+id/nav_captures"
+        android:title="@string/captures_title"
+        android:icon="@android:drawable/ic_menu_camera" />
+    <item
         android:id="@+id/nav_settings"
         android:title="@string/settings_title"
         android:icon="@android:drawable/ic_menu_preferences" />

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -54,6 +54,12 @@
     <string name="start_server">Start your Simple Computer Use server</string>
     <string name="switch_to_dark_theme">Switch to dark theme</string>
     <string name="settings_title">Configuración</string>
+    <string name="captures_title">Capturas</string>
+    <string name="captures_loading">Cargando capturas...</string>
+    <string name="captures_empty">No hay capturas disponibles</string>
+    <string name="captures_refresh">Actualizar</string>
+    <string name="timestamp_unavailable">Timestamp no disponible</string>
+    <string name="capture_image_description">Captura tomada %1$s</string>
     
     <!-- Recording Section -->
     <string name="start_recording">Start Recording</string>


### PR DESCRIPTION
### Motivation
- Ofrecer una pantalla dedicada para ver las últimas capturas (las 10 más recientes) ordenadas de arriba (más reciente) a abajo (menos reciente) con timestamp visible. 
- Mejorar la barra lateral (drawer) mostrando en su parte superior el logo y el nombre de la aplicación sin interacción y mantener la lista de accesos debajo. 
- Facilitar la experiencia añadiendo carga por swipe-to-refresh, caching de imágenes y timestamps legibles para el usuario.

### Description
- Se añade `CapturesActivity` que solicita `GET /screenshots/latest?limit=10`, convierte la respuesta en una lista de elementos con timestamp, y los ordena por fecha descendente para mostrarlos en pantalla. 
- Nuevos layouts y recursos: `activity_captures.xml`, `item_capture.xml`, `drawer_header.xml`, nuevo item de menú `nav_captures` en `drawer_menu.xml` y nuevas cadenas en `strings.xml`. 
- UI y utilidades: `RecyclerView` con `CapturesAdapter`, `SwipeRefreshLayout` para refrescar, `LruCache` para caching de bitmaps, parsing/normalización de timestamps (`FILENAME_TIMESTAMP_REGEX`) y formateo a `yyyy-MM-dd HH:mm:ss`. 
- Integración: se registra `CapturesActivity` en el `AndroidManifest.xml`, se añade la cabecera al `NavigationView` (portrait y landscape) y se enlaza la opción del cajón en `MainActivity`, además se añade la dependencia `androidx.swiperefreshlayout:swiperefreshlayout:1.1.0`.

### Testing
- No se ejecutaron pruebas automatizadas sobre los cambios (ninguna suite de tests fue corridа automáticamente).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694e44fc58088325a0e01248121d557e)