### PR TITLE
Add first-run tutorial modal

### DIFF
--- a/app/src/main/java/com/example/myapplication/MainActivity.kt
+++ b/app/src/main/java/com/example/myapplication/MainActivity.kt
@@ -285,6 +285,7 @@ class MainActivity : AppCompatActivity() {
         private const val KEY_IS_COMMAND_HISTORY_EXPANDED = "isCommandHistoryExpanded"
         private const val KEY_IS_FAVORITES_EXPANDED = "isFavoritesExpanded"
         private const val KEY_SCREENSHOT_REFRESH_PERIOD = "screenshotRefreshPeriod"
+        private const val KEY_TUTORIAL_SHOWN = "tutorialShown"
         private const val PERMISSION_REQUEST_RECORD_AUDIO = 100
     }
     
@@ -306,6 +307,8 @@ class MainActivity : AppCompatActivity() {
         
         // Load app preferences
         loadAppPreferences()
+
+        maybeShowTutorial()
         
         // Configure initial button states
         updateButtonStates()
@@ -410,6 +413,11 @@ class MainActivity : AppCompatActivity() {
                 }
                 R.id.nav_settings -> {
                     startActivity(Intent(this, SettingsActivity::class.java))
+                    drawerLayout.closeDrawer(GravityCompat.START)
+                    true
+                }
+                R.id.nav_tutorial -> {
+                    showTutorialDialog(markAsSeen = false)
                     drawerLayout.closeDrawer(GravityCompat.START)
                     true
                 }
@@ -1512,6 +1520,40 @@ class MainActivity : AppCompatActivity() {
         isLogsExpanded = prefs.getBoolean(KEY_IS_LOGS_EXPANDED, false)
         refreshPeriodMs = prefs.getLong(KEY_REFRESH_PERIOD, 30000)
         autoRefreshEnabled = prefs.getBoolean(KEY_AUTO_REFRESH_ENABLED, true)
+    }
+
+    private fun maybeShowTutorial() {
+        val prefs = getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+        if (!prefs.getBoolean(KEY_TUTORIAL_SHOWN, false)) {
+            window.decorView.post {
+                showTutorialDialog(markAsSeen = true)
+            }
+        }
+    }
+
+    private fun showTutorialDialog(markAsSeen: Boolean) {
+        val dialog = Dialog(this)
+        dialog.requestWindowFeature(Window.FEATURE_NO_TITLE)
+        dialog.setContentView(R.layout.dialog_tutorial)
+        dialog.window?.setBackgroundDrawable(ColorDrawable(Color.TRANSPARENT))
+        dialog.setCancelable(true)
+
+        dialog.findViewById<MaterialButton>(R.id.tutorialCloseButton).setOnClickListener {
+            dialog.dismiss()
+        }
+        dialog.findViewById<MaterialButton>(R.id.tutorialSettingsButton).setOnClickListener {
+            dialog.dismiss()
+            startActivity(Intent(this, SettingsActivity::class.java))
+        }
+        dialog.setOnDismissListener {
+            if (markAsSeen) {
+                val prefs = getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+                prefs.edit().putBoolean(KEY_TUTORIAL_SHOWN, true).apply()
+            }
+        }
+
+        dialog.show()
+        dialog.window?.setLayout(ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.MATCH_PARENT)
     }
     
     private fun saveAppPreferences() {

--- a/app/src/main/res/layout/dialog_tutorial.xml
+++ b/app/src/main/res/layout/dialog_tutorial.xml
@@ -1,0 +1,203 @@
+<?xml version="1.0" encoding="utf-8"?>
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:background="#99000000"
+    android:padding="24dp">
+
+    <com.google.android.material.card.MaterialCardView
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:layout_gravity="center"
+        app:cardBackgroundColor="@color/md_theme_surface"
+        app:cardCornerRadius="24dp"
+        app:cardElevation="6dp">
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:orientation="vertical">
+
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:background="@color/md_theme_primaryContainer"
+                android:orientation="vertical"
+                android:padding="20dp">
+
+                <TextView
+                    android:id="@+id/tutorialTitle"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:text="@string/tutorial_title"
+                    android:textColor="@color/md_theme_onPrimaryContainer"
+                    android:textSize="24sp"
+                    android:textStyle="bold" />
+
+                <TextView
+                    android:id="@+id/tutorialSubtitle"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="6dp"
+                    android:text="@string/tutorial_subtitle"
+                    android:textColor="@color/md_theme_onPrimaryContainer"
+                    android:textSize="14sp" />
+            </LinearLayout>
+
+            <ScrollView
+                android:layout_width="match_parent"
+                android:layout_height="0dp"
+                android:layout_weight="1"
+                android:fillViewport="true">
+
+                <LinearLayout
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:orientation="vertical"
+                    android:padding="20dp">
+
+                    <com.google.android.material.card.MaterialCardView
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:layout_marginBottom="16dp"
+                        app:cardBackgroundColor="@color/md_theme_secondaryContainer"
+                        app:cardCornerRadius="16dp"
+                        app:cardElevation="0dp">
+
+                        <LinearLayout
+                            android:layout_width="match_parent"
+                            android:layout_height="wrap_content"
+                            android:orientation="vertical"
+                            android:padding="16dp">
+
+                            <TextView
+                                android:layout_width="match_parent"
+                                android:layout_height="wrap_content"
+                                android:text="@string/tutorial_highlight_title"
+                                android:textColor="@color/md_theme_onSecondaryContainer"
+                                android:textSize="16sp"
+                                android:textStyle="bold" />
+
+                            <TextView
+                                android:layout_width="match_parent"
+                                android:layout_height="wrap_content"
+                                android:layout_marginTop="6dp"
+                                android:text="@string/tutorial_highlight_body"
+                                android:textColor="@color/md_theme_onSecondaryContainer"
+                                android:textSize="14sp" />
+                        </LinearLayout>
+                    </com.google.android.material.card.MaterialCardView>
+
+                    <TextView
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:text="@string/tutorial_steps_title"
+                        android:textColor="@color/md_theme_onSurface"
+                        android:textSize="18sp"
+                        android:textStyle="bold" />
+
+                    <TextView
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:layout_marginTop="6dp"
+                        android:layout_marginBottom="16dp"
+                        android:text="@string/tutorial_steps_body"
+                        android:textColor="@color/md_theme_onSurfaceVariant"
+                        android:textSize="14sp" />
+
+                    <TextView
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:text="@string/tutorial_commands_title"
+                        android:textColor="@color/md_theme_onSurface"
+                        android:textSize="18sp"
+                        android:textStyle="bold" />
+
+                    <TextView
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:layout_marginTop="6dp"
+                        android:layout_marginBottom="12dp"
+                        android:text="@string/tutorial_commands_body"
+                        android:textColor="@color/md_theme_onSurfaceVariant"
+                        android:textSize="14sp" />
+
+                    <com.google.android.material.card.MaterialCardView
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:layout_marginBottom="16dp"
+                        app:cardBackgroundColor="@color/md_theme_surfaceVariant"
+                        app:cardCornerRadius="14dp"
+                        app:cardElevation="0dp">
+
+                        <TextView
+                            android:layout_width="match_parent"
+                            android:layout_height="wrap_content"
+                            android:padding="14dp"
+                            android:text="@string/tutorial_commands_examples"
+                            android:textColor="@color/md_theme_onSurface"
+                            android:textSize="13sp"
+                            android:fontFamily="monospace" />
+                    </com.google.android.material.card.MaterialCardView>
+
+                    <TextView
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:text="@string/tutorial_voice_title"
+                        android:textColor="@color/md_theme_onSurface"
+                        android:textSize="18sp"
+                        android:textStyle="bold" />
+
+                    <TextView
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:layout_marginTop="6dp"
+                        android:layout_marginBottom="16dp"
+                        android:text="@string/tutorial_voice_body"
+                        android:textColor="@color/md_theme_onSurfaceVariant"
+                        android:textSize="14sp" />
+
+                    <TextView
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:text="@string/tutorial_tips_title"
+                        android:textColor="@color/md_theme_onSurface"
+                        android:textSize="18sp"
+                        android:textStyle="bold" />
+
+                    <TextView
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:layout_marginTop="6dp"
+                        android:text="@string/tutorial_tips_body"
+                        android:textColor="@color/md_theme_onSurfaceVariant"
+                        android:textSize="14sp" />
+                </LinearLayout>
+            </ScrollView>
+
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:gravity="end"
+                android:orientation="horizontal"
+                android:padding="16dp">
+
+                <com.google.android.material.button.MaterialButton
+                    android:id="@+id/tutorialSettingsButton"
+                    style="?attr/materialButtonOutlinedStyle"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginEnd="12dp"
+                    android:text="@string/tutorial_settings_button" />
+
+                <com.google.android.material.button.MaterialButton
+                    android:id="@+id/tutorialCloseButton"
+                    style="?attr/materialButtonStyle"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="@string/tutorial_close_button" />
+            </LinearLayout>
+        </LinearLayout>
+    </com.google.android.material.card.MaterialCardView>
+</FrameLayout>

--- a/app/src/main/res/menu/drawer_menu.xml
+++ b/app/src/main/res/menu/drawer_menu.xml
@@ -8,4 +8,8 @@
         android:id="@+id/nav_settings"
         android:title="@string/settings_title"
         android:icon="@android:drawable/ic_menu_preferences" />
+    <item
+        android:id="@+id/nav_tutorial"
+        android:title="@string/tutorial_menu_title"
+        android:icon="@android:drawable/ic_menu_help" />
 </menu>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -63,6 +63,22 @@
     <string name="captures_sort_oldest">Más antiguas primero</string>
     <string name="timestamp_unavailable">Timestamp no disponible</string>
     <string name="capture_image_description">Captura tomada %1$s</string>
+    <string name="tutorial_menu_title">Tutorial</string>
+    <string name="tutorial_title">Bienvenido a Simple Computer Use</string>
+    <string name="tutorial_subtitle">Controla tu ordenador remoto con comandos de voz o texto y revisa los resultados en tiempo real.</string>
+    <string name="tutorial_highlight_title">Tu guía en el primer inicio</string>
+    <string name="tutorial_highlight_body">Este tutorial aparece automáticamente la primera vez. También puedes abrirlo desde la barra lateral en “Tutorial”.</string>
+    <string name="tutorial_steps_title">Cómo empezar</string>
+    <string name="tutorial_steps_body">1. Configura la IP/puerto del servidor.\n2. Pulsa “Start Recording” y dicta tu comando.\n3. Espera la respuesta y revisa los pasos ejecutados.\n4. Usa las capturas y el resumen para validar el resultado.</string>
+    <string name="tutorial_commands_title">Ejemplos de comandos</string>
+    <string name="tutorial_commands_body">Describe la acción con claridad. Puedes combinar navegación, escritura y confirmaciones.</string>
+    <string name="tutorial_commands_examples">“Abre el navegador y busca hoteles en Madrid.”\n“Haz clic en la primera opción y desplázate hacia abajo.”\n“Escribe mi correo en el formulario y envíalo.”\n“Cambia a modo oscuro y sube el brillo al 80%.”</string>
+    <string name="tutorial_voice_title">Comandos de voz y texto</string>
+    <string name="tutorial_voice_body">Habla de forma natural o usa comandos directos. El sistema traduce a pasos accionables y puedes repetir una orden desde el historial.</string>
+    <string name="tutorial_tips_title">Consejos pro</string>
+    <string name="tutorial_tips_body">• Sé específico con botones, campos o pestañas.\n• Indica cuándo confirmar o cancelar.\n• Usa “captura pantalla” para actualizar la vista antes de una nueva orden.\n• Ajusta el modelo Whisper según velocidad o precisión.</string>
+    <string name="tutorial_settings_button">Configurar servidor</string>
+    <string name="tutorial_close_button">Entendido</string>
     
     <!-- Recording Section -->
     <string name="start_recording">Start Recording</string>


### PR DESCRIPTION
### Motivation
- Provide a first-run, feature-rich onboarding modal that explains how to use the app and shows command examples. 
- Surface the tutorial again on demand from the app sidebar for users who close it on first boot. 
- Keep all UI copy translatable so the tutorial is fully i18n-ready. 

### Description
- Add a new layout `dialog_tutorial.xml` implementing a polished, scrollable tutorial modal with examples and action buttons.  
- Add localized strings in `strings.xml` for all tutorial texts and button labels. 
- Add a `Tutorial` entry to the navigation drawer in `drawer_menu.xml` and wire it to open the modal. 
- Update `MainActivity.kt` to add `KEY_TUTORIAL_SHOWN`, call `maybeShowTutorial()` on startup, and implement `showTutorialDialog(markAsSeen: Boolean)` to present the dialog and persist the first-run state. 

### Testing
- No automated tests were executed for this change.  
- The change includes only UI and resource additions plus small preference logic; please run an Android build and manual QA on a device/emulator to validate dialog appearance and drawer item behavior.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694f249faf4083258d008e9d1e4b32fe)