### PR TITLE
Add shortcut to system TTS settings in settings screen

### DIFF
--- a/app/src/main/java/com/example/myapplication/SettingsActivity.kt
+++ b/app/src/main/java/com/example/myapplication/SettingsActivity.kt
@@ -8,7 +8,7 @@ import android.content.IntentFilter
 import android.net.Uri
 import android.os.Bundle
 import android.os.Handler
-import android.provider.Settings
+import android.speech.tts.TextToSpeech
 import android.util.Log
 import android.widget.ArrayAdapter
 import android.widget.AutoCompleteTextView
@@ -371,7 +371,7 @@ class SettingsActivity : AppCompatActivity() {
     }
 
     private fun openTtsSystemSettings() {
-        val intent = Intent(Settings.ACTION_TTS_SETTINGS)
+        val intent = Intent(TextToSpeech.Engine.ACTION_TTS_SETTINGS)
         try {
             startActivity(intent)
         } catch (e: ActivityNotFoundException) {

--- a/app/src/main/java/com/example/myapplication/SettingsActivity.kt
+++ b/app/src/main/java/com/example/myapplication/SettingsActivity.kt
@@ -8,7 +8,7 @@ import android.content.IntentFilter
 import android.net.Uri
 import android.os.Bundle
 import android.os.Handler
-import android.speech.tts.TextToSpeech
+import android.provider.Settings
 import android.util.Log
 import android.widget.ArrayAdapter
 import android.widget.AutoCompleteTextView
@@ -371,13 +371,16 @@ class SettingsActivity : AppCompatActivity() {
     }
 
     private fun openTtsSystemSettings() {
-        val intent = Intent(TextToSpeech.Engine.ACTION_TTS_SETTINGS)
         try {
-            startActivity(intent)
+            startActivity(Intent(TTS_SETTINGS_ACTION))
         } catch (e: ActivityNotFoundException) {
-            Log.e("SettingsActivity", "TTS settings unavailable", e)
-            Toast.makeText(this, getString(R.string.tts_settings_unavailable), Toast.LENGTH_SHORT)
-                .show()
+            try {
+                startActivity(Intent(Settings.ACTION_SETTINGS))
+            } catch (fallbackException: ActivityNotFoundException) {
+                Log.e("SettingsActivity", "TTS settings unavailable", fallbackException)
+                Toast.makeText(this, getString(R.string.tts_settings_unavailable), Toast.LENGTH_SHORT)
+                    .show()
+            }
         }
     }
 
@@ -386,5 +389,6 @@ class SettingsActivity : AppCompatActivity() {
         private const val KEY_IS_DARK_THEME = "isDarkTheme"
         private const val KEY_UNLOCK_PASSWORD = "unlockPassword"
         private const val KEY_RESPONSE_TIMEOUT = AudioService.KEY_RESPONSE_TIMEOUT
+        private const val TTS_SETTINGS_ACTION = "android.speech.tts.engine.TTS_SETTINGS"
     }
 }

--- a/app/src/main/java/com/example/myapplication/SettingsActivity.kt
+++ b/app/src/main/java/com/example/myapplication/SettingsActivity.kt
@@ -1,5 +1,6 @@
 package com.example.myapplication
 
+import android.content.ActivityNotFoundException
 import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
@@ -7,6 +8,7 @@ import android.content.IntentFilter
 import android.net.Uri
 import android.os.Bundle
 import android.os.Handler
+import android.provider.Settings
 import android.util.Log
 import android.widget.ArrayAdapter
 import android.widget.AutoCompleteTextView
@@ -34,6 +36,7 @@ class SettingsActivity : AppCompatActivity() {
     private lateinit var ttsLanguageInput: TextInputEditText
     private lateinit var ttsRateInput: TextInputEditText
     private lateinit var ttsPitchInput: TextInputEditText
+    private lateinit var btnTtsSystemSettings: MaterialButton
     private lateinit var audioPlaybackSwitch: SwitchMaterial
     private lateinit var btnTestConnection: MaterialButton
     private lateinit var btnSaveSettings: MaterialButton
@@ -100,6 +103,7 @@ class SettingsActivity : AppCompatActivity() {
         ttsLanguageInput = findViewById(R.id.ttsLanguageInput)
         ttsRateInput = findViewById(R.id.ttsRateInput)
         ttsPitchInput = findViewById(R.id.ttsPitchInput)
+        btnTtsSystemSettings = findViewById(R.id.btnTtsSystemSettings)
         audioPlaybackSwitch = findViewById(R.id.audioPlaybackSwitch)
         btnTestConnection = findViewById(R.id.btnTestConnection)
         btnSaveSettings = findViewById(R.id.btnSaveSettings)
@@ -130,6 +134,10 @@ class SettingsActivity : AppCompatActivity() {
 
         btnTestConnection.setOnClickListener {
             testServerConnection()
+        }
+
+        btnTtsSystemSettings.setOnClickListener {
+            openTtsSystemSettings()
         }
 
         audioPlaybackSwitch.setOnCheckedChangeListener { _, isChecked ->
@@ -360,6 +368,17 @@ class SettingsActivity : AppCompatActivity() {
         audioPlaybackSwitch.text = getString(
             if (enabled) R.string.audio_playback_enabled else R.string.audio_playback_disabled
         )
+    }
+
+    private fun openTtsSystemSettings() {
+        val intent = Intent(Settings.ACTION_TTS_SETTINGS)
+        try {
+            startActivity(intent)
+        } catch (e: ActivityNotFoundException) {
+            Log.e("SettingsActivity", "TTS settings unavailable", e)
+            Toast.makeText(this, getString(R.string.tts_settings_unavailable), Toast.LENGTH_SHORT)
+                .show()
+        }
     }
 
     companion object {

--- a/app/src/main/res/layout/activity_settings.xml
+++ b/app/src/main/res/layout/activity_settings.xml
@@ -185,6 +185,16 @@
                             android:maxLines="1" />
                     </com.google.android.material.textfield.TextInputLayout>
 
+                    <com.google.android.material.button.MaterialButton
+                        android:id="@+id/btnTtsSystemSettings"
+                        style="@style/Widget.Material3.Button.OutlinedButton"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:layout_marginTop="8dp"
+                        android:text="@string/tts_system_settings"
+                        app:icon="@android:drawable/ic_menu_manage"
+                        app:iconGravity="start" />
+
                     <com.google.android.material.switchmaterial.SwitchMaterial
                         android:id="@+id/audioPlaybackSwitch"
                         android:layout_width="match_parent"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -20,6 +20,8 @@
     <string name="tts_language_hint">TTS Language (e.g. es-ES)</string>
     <string name="tts_rate_hint">TTS Speed (0.1 - 2.0)</string>
     <string name="tts_pitch_hint">TTS Pitch (0.1 - 2.0)</string>
+    <string name="tts_system_settings">Ajustes de síntesis de voz</string>
+    <string name="tts_settings_unavailable">No se pudieron abrir los ajustes de síntesis de voz</string>
     <string name="test_connection">Test Connection</string>
     <string name="whisper_model_hint">Whisper Model Size</string>
     <string name="whisper_model_help">More accurate models require more resources:\n• tiny: ~39M parameters (~75 MB) - Very fast, less accurate\n• base: ~74M parameters (~142 MB) - Balanced (default)\n• small: ~244M parameters (~466 MB) - Good accuracy and speed\n• medium: ~769M parameters (~1.5 GB) - More accurate, slower\n• large: ~1550M parameters (~2.9 GB) - Maximum accuracy</string>


### PR DESCRIPTION
### Motivation
- Provide a convenient entry point from the app to the Android system Text-to-Speech settings so users can configure engine, language, rate and pitch.
- Use the platform-provided TTS settings intent for a best-effort, OEM-compatible navigation to system TTS configuration.
- Avoid coupling to any specific TTS engine or requiring extra permissions by launching the standard system intent.

### Description
- Add a new `MaterialButton` (`btnTtsSystemSettings`) to `activity_settings.xml` placed near the TTS inputs. 
- Add two new strings: `tts_system_settings` and `tts_settings_unavailable` in `strings.xml` for button label and error fallback. 
- Wire the view in `SettingsActivity` with `findViewById`, set a click listener to call `openTtsSystemSettings()`, and implement that method to launch `Settings.ACTION_TTS_SETTINGS` while catching `ActivityNotFoundException` to log and show a `Toast` fallback. 
- Import `Settings` and `ActivityNotFoundException` and update the code accordingly.

### Testing
- Executed a smoke build with `./gradlew assembleDebug` which failed due to a missing Android SDK location (`local.properties` / `ANDROID_HOME`).
- No other automated tests were run in this environment due to the SDK/build configuration missing.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694fd6cf2a848325aa6890b50dd5738b)