### PR TITLE
Update tutorial copy, remove summary info button, and add Copy logs action

### DIFF
--- a/app/src/main/java/com/example/myapplication/MainActivity.kt
+++ b/app/src/main/java/com/example/myapplication/MainActivity.kt
@@ -53,7 +53,6 @@ import android.widget.PopupMenu
 import android.view.animation.Animation
 import android.view.animation.AnimationUtils
 import androidx.interpolator.view.animation.FastOutSlowInInterpolator
-import androidx.appcompat.app.AlertDialog
 import androidx.appcompat.app.AppCompatDelegate
 import androidx.lifecycle.lifecycleScope
 import androidx.constraintlayout.widget.ConstraintLayout
@@ -71,6 +70,8 @@ import com.example.myapplication.AudioService.Companion.KEY_SERVER_IP
 import com.example.myapplication.AudioService.Companion.KEY_SERVER_PORT
 import kotlin.math.sqrt
 import android.widget.ProgressBar
+import android.content.ClipData
+import android.content.ClipboardManager
 import com.google.android.material.card.MaterialCardView
 import com.google.android.material.color.MaterialColors
 import com.google.android.material.switchmaterial.SwitchMaterial
@@ -96,6 +97,7 @@ class MainActivity : AppCompatActivity() {
     
     // Logs - Find ScrollView directly by ID
     private lateinit var logsTextView: TextView
+    private lateinit var btnCopyLogs: MaterialButton
     private lateinit var btnClearLogs: MaterialButton
     private lateinit var logsScrollView: ScrollView
     private lateinit var btnToggleLogs: MaterialButton
@@ -526,6 +528,7 @@ class MainActivity : AppCompatActivity() {
         
         // Logs - Find ScrollView directly by ID
         logsTextView = findViewById(R.id.logsTextView)
+        btnCopyLogs = findViewById(R.id.btnCopyLogs)
         btnClearLogs = findViewById(R.id.btnClearLogs)
         logsScrollView = findViewById(R.id.logsScrollView)
         
@@ -564,12 +567,6 @@ class MainActivity : AppCompatActivity() {
             playLastAudio()
         }
         
-        // Voice control info button
-        val btnVoiceControlInfo = findViewById<MaterialButton>(R.id.btnVoiceControlInfo)
-        btnVoiceControlInfo.setOnClickListener {
-            showVoiceControlInfoDialog()
-        }
-        
         updateScreenSummary("")
 
         updateHeadsetControlUi(headsetControlEnabled)
@@ -580,6 +577,16 @@ class MainActivity : AppCompatActivity() {
             logBuffer.clear()
             logsTextView.text = ""
             addLogMessage("[${getCurrentTime()}] ${getString(R.string.logs_cleared)}")
+        }
+
+        btnCopyLogs.setOnClickListener {
+            val clipboard = getSystemService(Context.CLIPBOARD_SERVICE) as ClipboardManager
+            val clip = ClipData.newPlainText(
+                getString(R.string.logs_title),
+                logsTextView.text.toString()
+            )
+            clipboard.setPrimaryClip(clip)
+            Toast.makeText(this, getString(R.string.logs_copied), Toast.LENGTH_SHORT).show()
         }
         
         // Setup log toggle button
@@ -1874,27 +1881,6 @@ class MainActivity : AppCompatActivity() {
 
         dialog.show()
         dialog.window?.setLayout(ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.MATCH_PARENT)
-    }
-    
-    private fun showVoiceControlInfoDialog() {
-        AlertDialog.Builder(this)
-            .setTitle("Control de Voz Manos Libres")
-            .setMessage("""
-                Este modo te permite controlar la aplicación usando los botones de tus auriculares Bluetooth.
-                
-                Cómo funciona:
-                
-                • 1 toque: Iniciar/Detener grabación
-                • 2 toques rápidos: Detener y enviar
-                • 3 toques rápidos: Cancelar grabación
-                
-                El sistema reproduce audio silencioso en segundo plano para mantener el control de los botones.
-                
-                Nota: Desactiva el modo cuando no lo uses para ahorrar batería.
-            """.trimIndent())
-            .setIcon(android.R.drawable.ic_menu_info_details)
-            .setPositiveButton("Entendido") { dialog, _ -> dialog.dismiss() }
-            .show()
     }
     
     private fun saveAppPreferences() {

--- a/app/src/main/res/layout-land/activity_main.xml
+++ b/app/src/main/res/layout-land/activity_main.xml
@@ -227,15 +227,6 @@
                             android:textAppearance="?attr/textAppearanceTitleMedium" />
 
                         <com.google.android.material.button.MaterialButton
-                            android:id="@+id/btnVoiceControlInfo"
-                            style="@style/Widget.Material3.Button.IconButton"
-                            android:layout_width="48dp"
-                            android:layout_height="48dp"
-                            android:contentDescription="@string/voice_control_info"
-                            app:icon="@android:drawable/ic_menu_info_details"
-                            app:iconSize="24dp" />
-
-                        <com.google.android.material.button.MaterialButton
                             android:id="@+id/btnPlaySummary"
                             style="@style/Widget.Material3.Button.TextButton"
                             android:layout_width="wrap_content"
@@ -501,6 +492,17 @@
                             android:layout_weight="1"
                             android:text="@string/logs_title"
                             android:textAppearance="?attr/textAppearanceTitleMedium" />
+
+                        <com.google.android.material.button.MaterialButton
+                            android:id="@+id/btnCopyLogs"
+                            style="@style/Widget.Material3.Button.TextButton"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:minWidth="80dp"
+                            android:minHeight="48dp"
+                            android:text="@string/copy"
+                            android:textSize="14sp"
+                            app:icon="@android:drawable/ic_menu_save" />
 
                         <com.google.android.material.button.MaterialButton
                             android:id="@+id/btnClearLogs"

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -225,15 +225,6 @@
                             android:textAppearance="?attr/textAppearanceTitleMedium" />
 
                         <com.google.android.material.button.MaterialButton
-                            android:id="@+id/btnVoiceControlInfo"
-                            style="@style/Widget.Material3.Button.IconButton"
-                            android:layout_width="48dp"
-                            android:layout_height="48dp"
-                            android:contentDescription="@string/voice_control_info"
-                            app:icon="@android:drawable/ic_menu_info_details"
-                            app:iconSize="24dp" />
-
-                        <com.google.android.material.button.MaterialButton
                             android:id="@+id/btnPlaySummary"
                             style="@style/Widget.Material3.Button.TextButton"
                             android:layout_width="wrap_content"
@@ -499,6 +490,17 @@
                             android:layout_weight="1"
                             android:text="@string/logs_title"
                             android:textAppearance="?attr/textAppearanceTitleMedium" />
+
+                        <com.google.android.material.button.MaterialButton
+                            android:id="@+id/btnCopyLogs"
+                            style="@style/Widget.Material3.Button.TextButton"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:minWidth="80dp"
+                            android:minHeight="48dp"
+                            android:text="@string/copy"
+                            android:textSize="14sp"
+                            app:icon="@android:drawable/ic_menu_save" />
 
                         <com.google.android.material.button.MaterialButton
                             android:id="@+id/btnClearLogs"

--- a/app/src/main/res/layout/dialog_tutorial.xml
+++ b/app/src/main/res/layout/dialog_tutorial.xml
@@ -26,14 +26,29 @@
                 android:orientation="vertical"
                 android:padding="20dp">
 
-                <TextView
-                    android:id="@+id/tutorialTitle"
+                <LinearLayout
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:text="@string/tutorial_title"
-                    android:textColor="@color/md_theme_onPrimaryContainer"
-                    android:textSize="24sp"
-                    android:textStyle="bold" />
+                    android:gravity="center_vertical"
+                    android:orientation="horizontal">
+
+                    <TextView
+                        android:id="@+id/tutorialTitle"
+                        android:layout_width="0dp"
+                        android:layout_height="wrap_content"
+                        android:layout_weight="1"
+                        android:text="@string/tutorial_title"
+                        android:textColor="@color/md_theme_onPrimaryContainer"
+                        android:textSize="24sp"
+                        android:textStyle="bold" />
+
+                    <ImageView
+                        android:layout_width="24dp"
+                        android:layout_height="24dp"
+                        android:layout_marginStart="12dp"
+                        android:contentDescription="@string/app_logo"
+                        android:src="@mipmap/ic_launcher" />
+                </LinearLayout>
 
                 <TextView
                     android:id="@+id/tutorialSubtitle"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -12,6 +12,7 @@
 
     <!-- UI Strings -->
     <string name="logs_title">Logs (Logcat)</string>
+    <string name="copy">Copy</string>
     <string name="clear">Clear</string>
     <string name="server_ip_hint">Server IP</string>
     <string name="server_port_hint">Server Port</string>
@@ -66,19 +67,19 @@
     <string name="timestamp_unavailable">Timestamp no disponible</string>
     <string name="capture_image_description">Captura tomada %1$s</string>
     <string name="tutorial_menu_title">Tutorial</string>
-    <string name="tutorial_title">Bienvenido a Simple Computer Use</string>
-    <string name="tutorial_subtitle">Controla tu ordenador remoto con comandos de voz o texto y revisa los resultados en tiempo real.</string>
+    <string name="tutorial_title">Bienvenido</string>
+    <string name="tutorial_subtitle">Controla tu ordenador por voz o texto, con lenguaje natural. Da órdenes como las darías a un compañero que maneja un ordenador.</string>
     <string name="tutorial_highlight_title">Tu guía en el primer inicio</string>
     <string name="tutorial_highlight_body">Este tutorial aparece automáticamente la primera vez. También puedes abrirlo desde la barra lateral en “Tutorial”.</string>
     <string name="tutorial_steps_title">Cómo empezar</string>
-    <string name="tutorial_steps_body">1. Configura la IP/puerto del servidor.\n2. Pulsa “Start Recording” y dicta tu comando.\n3. Espera la respuesta y revisa los pasos ejecutados.\n4. Usa las capturas y el resumen para validar el resultado.</string>
-    <string name="tutorial_commands_title">Ejemplos de comandos</string>
-    <string name="tutorial_commands_body">Describe la acción con claridad usando keywords simples como click, escribe o presiona.</string>
+    <string name="tutorial_steps_body">1. Ve a configuración y ajusta la IP y puerto del PC con la Desktop app instalada y corriendo.\n2. Pulsa “Start Recording” y dicta tu comando.\n3. Espera ejecución y revisa los pasos ejecutados en Command History.\n4. Usa las capturas y el resumen para validar el resultado.</string>
+    <string name="tutorial_commands_title">3 comandos: click, escribe, presiona</string>
+    <string name="tutorial_commands_body">Describe la acción con claridad usando keywords como click, escribe o presiona.</string>
     <string name="tutorial_commands_examples">“Click en Ajustes”\n“escribe hola mundo Lorem ipsum”\n“scroll abajo”\n“presiona Control Shift T”</string>
-    <string name="tutorial_voice_title">Comandos de voz y texto</string>
-    <string name="tutorial_voice_body">Habla de forma natural o usa comandos directos. El sistema traduce a pasos accionables y puedes repetir una orden desde el historial.</string>
+    <string name="tutorial_voice_title">Dicta varios pasos seguidos</string>
+    <string name="tutorial_voice_body">Dicta varios comandos en la misma petición, como &quot;click Firefox, escribe google, presiona enter&quot;. Una LLM los segmenta adecuadamente en pasos: puedes comprobarlo en Command History.</string>
     <string name="tutorial_tips_title">Consejos pro</string>
-    <string name="tutorial_tips_body">• Sé específico con el texto en botones, campos o pestañas.\n• Usa “captura pantalla” para actualizar la vista antes de una nueva orden.</string>
+    <string name="tutorial_tips_body">• Para las órdenes de click, sé específico con el texto en botones, campos o pestañas: el blanco del click usa OCR.\n• Los tiempos de ejecución de cada orden varían según la potencia del equipo, tamaño de los modelos usados, y disponibilidad de GPU.</string>
     <string name="tutorial_settings_button">Configurar servidor</string>
     <string name="tutorial_close_button">Entendido</string>
     
@@ -185,6 +186,8 @@
     <string name="unknown_error">Unknown error</string>
     <string name="app_started">Application started</string>
     <string name="logs_cleared">Logs cleared</string>
+    <string name="logs_copied">Logs copied to clipboard</string>
+    <string name="app_logo">Logo de la app</string>
     <string name="recording_state_reset">Recording state reset</string>
     <string name="server_settings_updated">Server settings updated: %1$s:%2$s, model: %3$s</string>
     <string name="testing_connection">Testing connection to %1$s...</string>
@@ -291,7 +294,6 @@
     <string name="headset_control_status_off">Manos libres: desactivado</string>
     <string name="headset_control_status_pending">Manos libres: solicitando…</string>
     <string name="headset_control_status_timeout">Manos libres: sin respuesta</string>
-    <string name="voice_control_info">Información sobre control de voz</string>
     <string name="drawer_mic_inactive">Mic: No activo</string>
     <string name="drawer_mic_device">Mic: %1$s</string>
     <string name="headset_feedback_enabled">Feedback auditivo en auriculares</string>


### PR DESCRIPTION
### Motivation

- Simplify and clarify the tutorial modal copy and header to make onboarding shorter and more actionable. 
- Remove the summary card info icon and its modal to reduce UI clutter. 
- Add a quick way to copy logs from the Logs card so users can share or paste logs easily. 

### Description

- Removed the summary info icon and the `showVoiceControlInfoDialog` hook from `activity_main.xml` and `MainActivity.kt`. 
- Added a `Copy` button in the Logs header in both portrait and landscape layouts and wired it to a new `btnCopyLogs` handler in `MainActivity.kt` that copies `logsTextView` contents to the clipboard. 
- Updated the tutorial dialog layout to include a small app logo in the top-right and replaced multiple tutorial strings in `strings.xml` to the new copy requested. 
- Files changed include `MainActivity.kt`, `activity_main.xml`, `activity_main.xml (land)`, `dialog_tutorial.xml`, and `values/strings.xml` to apply the UI and string updates. 

### Testing

- Attempted an automated smoke build with `./gradlew :app:assembleDebug`, which failed due to a missing Android SDK (`local.properties`/`ANDROID_HOME`).
- No unit or instrumentation tests were executed as the build environment lacks the Android SDK, so runtime verification was not possible.
- Verified layout and string updates locally via static inspection and ensured `btnCopyLogs` is registered and handled in `MainActivity.kt` by running code searches. 
- Committed the changes after verification of the source edits (`git` operations performed locally).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695914b6a60c8325a8511fb22aa4ae72)