### PR TITLE
Add VNC connection screen and API flow

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -64,7 +64,6 @@ dependencies {
     implementation(libs.androidx.activity)
     implementation(libs.androidx.constraintlayout)
     implementation("androidx.swiperefreshlayout:swiperefreshlayout:1.1.0")
-    implementation("com.github.bk138:android-vnc-viewer:2.1.0")
     testImplementation(libs.junit)
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.espresso.core)

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -64,6 +64,7 @@ dependencies {
     implementation(libs.androidx.activity)
     implementation(libs.androidx.constraintlayout)
     implementation("androidx.swiperefreshlayout:swiperefreshlayout:1.1.0")
+    implementation("com.github.bk138:android-vnc-viewer:2.1.0")
     testImplementation(libs.junit)
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.espresso.core)

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -64,7 +64,6 @@ dependencies {
     implementation(libs.androidx.activity)
     implementation(libs.androidx.constraintlayout)
     implementation("androidx.swiperefreshlayout:swiperefreshlayout:1.1.0")
-    implementation("com.glavsoft:android-vnc-viewer:0.9.10")
     testImplementation(libs.junit)
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.espresso.core)

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -64,6 +64,7 @@ dependencies {
     implementation(libs.androidx.activity)
     implementation(libs.androidx.constraintlayout)
     implementation("androidx.swiperefreshlayout:swiperefreshlayout:1.1.0")
+    implementation(project(":vncviewer"))
     testImplementation(libs.junit)
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.espresso.core)

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -64,6 +64,7 @@ dependencies {
     implementation(libs.androidx.activity)
     implementation(libs.androidx.constraintlayout)
     implementation("androidx.swiperefreshlayout:swiperefreshlayout:1.1.0")
+    implementation("com.glavsoft:android-vnc-viewer:0.9.10")
     testImplementation(libs.junit)
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.espresso.core)

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -46,6 +46,10 @@
             android:name=".CapturesActivity"
             android:exported="false"
             android:label="@string/captures_title" />
+        <activity
+            android:name=".VncConnectionActivity"
+            android:exported="false"
+            android:label="@string/vnc_connection_title" />
 
         <!-- Servicio de audio en primer plano -->
         <service

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -50,6 +50,10 @@
             android:name=".VncConnectionActivity"
             android:exported="false"
             android:label="@string/vnc_connection_title" />
+        <activity
+            android:name=".VncStreamActivity"
+            android:exported="false"
+            android:label="@string/vnc_stream_title" />
 
         <!-- Servicio de audio en primer plano -->
         <service

--- a/app/src/main/java/com/example/myapplication/MainActivity.kt
+++ b/app/src/main/java/com/example/myapplication/MainActivity.kt
@@ -896,6 +896,10 @@ class MainActivity : AppCompatActivity() {
             startActivity(Intent(this, CapturesActivity::class.java))
             drawerLayout.closeDrawer(GravityCompat.START)
         }
+        navigationView.findViewById<View>(R.id.nav_vnc)?.setOnClickListener {
+            startActivity(Intent(this, VncConnectionActivity::class.java))
+            drawerLayout.closeDrawer(GravityCompat.START)
+        }
         navigationView.findViewById<View>(R.id.nav_settings)?.setOnClickListener {
             startActivity(Intent(this, SettingsActivity::class.java))
             drawerLayout.closeDrawer(GravityCompat.START)

--- a/app/src/main/java/com/example/myapplication/MainActivity.kt
+++ b/app/src/main/java/com/example/myapplication/MainActivity.kt
@@ -2041,6 +2041,7 @@ class MainActivity : AppCompatActivity() {
             stopAutoRefresh()
             screenshotImageView.visibility = View.GONE
             vncStreamContainer.visibility = View.VISIBLE
+            screenshotLoadingProgress.visibility = View.GONE
             btnCaptureScreenshot.isEnabled = false
             btnUnlockScreen.isEnabled = false
             btnRefreshPeriod.isEnabled = false
@@ -2050,6 +2051,7 @@ class MainActivity : AppCompatActivity() {
             stopVncStream()
             screenshotImageView.visibility = View.VISIBLE
             vncStreamContainer.visibility = View.GONE
+            screenshotLoadingProgress.visibility = View.GONE
             btnCaptureScreenshot.isEnabled = true
             btnUnlockScreen.isEnabled = true
             btnRefreshPeriod.isEnabled = true

--- a/app/src/main/java/com/example/myapplication/MainActivity.kt
+++ b/app/src/main/java/com/example/myapplication/MainActivity.kt
@@ -115,7 +115,11 @@ class MainActivity : AppCompatActivity() {
     private lateinit var btnCaptureScreenshot: MaterialButton
     private lateinit var btnUnlockScreen: MaterialButton
     private lateinit var btnRefreshPeriod: MaterialButton
+    private lateinit var switchVncMode: SwitchMaterial
+    private lateinit var vncStreamContainer: FrameLayout
     lateinit var screenshotLoadingProgress: ProgressBar
+    private var vncView: android.vnc.VncCanvasView? = null
+    private var isVncModeEnabled: Boolean = false
 
     // Screen summary section
     private lateinit var summaryCard: MaterialCardView
@@ -537,6 +541,7 @@ class MainActivity : AppCompatActivity() {
         // Stop any scheduled timers
         responseTimeoutHandler?.removeCallbacksAndMessages(null)
         stopAutoRefresh()
+        stopVncStream()
     }
     
     override fun onDestroy() {
@@ -614,6 +619,8 @@ class MainActivity : AppCompatActivity() {
         btnCaptureScreenshot = findViewById(R.id.btnCaptureScreenshot)
         btnUnlockScreen = findViewById(R.id.btnUnlockScreen)
         btnRefreshPeriod = findViewById(R.id.btnRefreshPeriod)
+        switchVncMode = findViewById(R.id.switchVncMode)
+        vncStreamContainer = findViewById(R.id.vncStreamContainerMain)
         screenshotLoadingProgress = findViewById(R.id.screenshotLoadingProgress)
 
         // Screen summary section
@@ -681,6 +688,15 @@ class MainActivity : AppCompatActivity() {
 
         updateHeadsetControlUi(headsetControlEnabled)
         updateMicrophoneStatus(null) // Initial state
+
+        val vncPrefs = getSharedPreferences(AudioService.PREFS_NAME, Context.MODE_PRIVATE)
+        isVncModeEnabled = vncPrefs.getBoolean(VncPreferences.KEY_VNC_MODE_ENABLED, false)
+        switchVncMode.isChecked = isVncModeEnabled
+        switchVncMode.setOnCheckedChangeListener { _, isChecked ->
+            isVncModeEnabled = isChecked
+            vncPrefs.edit().putBoolean(VncPreferences.KEY_VNC_MODE_ENABLED, isChecked).apply()
+            applyVncMode(isChecked)
+        }
         
         // Setup log clear button
         btnClearLogs.setOnClickListener {
@@ -894,10 +910,6 @@ class MainActivity : AppCompatActivity() {
         // Find custom menu items in drawer_content layout
         navigationView.findViewById<View>(R.id.nav_captures)?.setOnClickListener {
             startActivity(Intent(this, CapturesActivity::class.java))
-            drawerLayout.closeDrawer(GravityCompat.START)
-        }
-        navigationView.findViewById<View>(R.id.nav_vnc)?.setOnClickListener {
-            startActivity(Intent(this, VncConnectionActivity::class.java))
             drawerLayout.closeDrawer(GravityCompat.START)
         }
         navigationView.findViewById<View>(R.id.nav_settings)?.setOnClickListener {
@@ -1630,20 +1642,30 @@ class MainActivity : AppCompatActivity() {
         
         // Fetch initial screenshot with a slight delay to allow the UI to initialize
         Handler(mainLooper).postDelayed({
-            captureNewScreenshot()
+            if (!isVncModeEnabled) {
+                captureNewScreenshot()
+            }
         }, 1000)
         
         // Setup auto-refresh
         if (autoRefreshEnabled) {
-            startAutoRefresh()
+            if (!isVncModeEnabled) {
+                startAutoRefresh()
+            }
         }
         
         btnCaptureScreenshot.setOnClickListener {
-            captureNewScreenshot()
+            if (!isVncModeEnabled) {
+                captureNewScreenshot()
+            }
         }
+        applyVncMode(isVncModeEnabled)
     }
     
     private fun fetchLatestScreenshot() {
+        if (isVncModeEnabled) {
+            return
+        }
         screenshotScope.launch {
             try {
                 updateScreenshotState(ScreenshotState.Loading)
@@ -1984,6 +2006,10 @@ class MainActivity : AppCompatActivity() {
     private fun startAutoRefresh() {
         // Cancel any existing auto-refresh
         stopAutoRefresh()
+
+        if (isVncModeEnabled) {
+            return
+        }
         
         // Don't start if auto-refresh is disabled
         if (!autoRefreshEnabled) {
@@ -2008,6 +2034,52 @@ class MainActivity : AppCompatActivity() {
             refreshHandler?.removeCallbacks(runnable)
         }
         refreshRunnable = null
+    }
+
+    private fun applyVncMode(enabled: Boolean) {
+        if (enabled) {
+            stopAutoRefresh()
+            screenshotImageView.visibility = View.GONE
+            vncStreamContainer.visibility = View.VISIBLE
+            btnCaptureScreenshot.isEnabled = false
+            btnUnlockScreen.isEnabled = false
+            btnRefreshPeriod.isEnabled = false
+            screenshotStatusText.text = getString(R.string.vnc_mode_active)
+            startVncStream()
+        } else {
+            stopVncStream()
+            screenshotImageView.visibility = View.VISIBLE
+            vncStreamContainer.visibility = View.GONE
+            btnCaptureScreenshot.isEnabled = true
+            btnUnlockScreen.isEnabled = true
+            btnRefreshPeriod.isEnabled = true
+            screenshotStatusText.text = getString(R.string.no_screenshots_available)
+            if (autoRefreshEnabled) {
+                startAutoRefresh()
+            }
+        }
+    }
+
+    private fun startVncStream() {
+        val prefs = getSharedPreferences(AudioService.PREFS_NAME, Context.MODE_PRIVATE)
+        val host = prefs.getString(AudioService.KEY_SERVER_IP, AudioService.DEFAULT_SERVER_IP)
+            ?: AudioService.DEFAULT_SERVER_IP
+        val vncPort = prefs.getInt(VncPreferences.KEY_VNC_PORT, VncPreferences.DEFAULT_VNC_PORT)
+        val vncPassword = prefs.getString(VncPreferences.KEY_VNC_PASSWORD, "").orEmpty()
+        if (vncView == null) {
+            vncView = android.vnc.VncCanvasView(this)
+            vncStreamContainer.removeAllViews()
+            vncStreamContainer.addView(vncView)
+        }
+        vncView?.setConnectionInfo(host, vncPort, vncPassword)
+        vncView?.connect()
+    }
+
+    private fun stopVncStream() {
+        vncView?.disconnect()
+        vncView?.shutdown()
+        vncView = null
+        vncStreamContainer.removeAllViews()
     }
 
     private fun showRefreshPeriodMenu() {
@@ -2203,6 +2275,9 @@ class MainActivity : AppCompatActivity() {
     }
     
     private fun captureNewScreenshot() {
+        if (isVncModeEnabled) {
+            return
+        }
         screenshotScope.launch {
             try {
                 // Show loading progress bar instead of just text

--- a/app/src/main/java/com/example/myapplication/SettingsActivity.kt
+++ b/app/src/main/java/com/example/myapplication/SettingsActivity.kt
@@ -43,6 +43,8 @@ class SettingsActivity : AppCompatActivity() {
     private lateinit var serverPortInput: TextInputEditText
     private lateinit var unlockPasswordInput: TextInputEditText
     private lateinit var responseTimeoutInput: TextInputEditText
+    private lateinit var vncPortInput: TextInputEditText
+    private lateinit var vncPasswordInput: TextInputEditText
     private lateinit var ttsLanguageInput: TextInputEditText
     private lateinit var ttsRateInput: TextInputEditText
     private lateinit var ttsPitchInput: TextInputEditText
@@ -115,6 +117,8 @@ class SettingsActivity : AppCompatActivity() {
         serverPortInput = findViewById(R.id.serverPortInput)
         unlockPasswordInput = findViewById(R.id.unlockPasswordInput)
         responseTimeoutInput = findViewById(R.id.responseTimeoutInput)
+        vncPortInput = findViewById(R.id.vncPortInput)
+        vncPasswordInput = findViewById(R.id.vncPasswordInput)
         ttsLanguageInput = findViewById(R.id.ttsLanguageInput)
         ttsRateInput = findViewById(R.id.ttsRateInput)
         ttsPitchInput = findViewById(R.id.ttsPitchInput)
@@ -239,6 +243,8 @@ class SettingsActivity : AppCompatActivity() {
             ?: AudioService.DEFAULT_WHISPER_MODEL
         val unlockPassword = prefs.getString(KEY_UNLOCK_PASSWORD, "your_password") ?: "your_password"
         val responseTimeout = prefs.getInt(KEY_RESPONSE_TIMEOUT, AudioService.DEFAULT_RESPONSE_TIMEOUT)
+        val vncPort = prefs.getInt(VncPreferences.KEY_VNC_PORT, VncPreferences.DEFAULT_VNC_PORT)
+        val vncPassword = prefs.getString(VncPreferences.KEY_VNC_PASSWORD, "")
         val ttsLanguage = prefs.getString(KEY_TTS_LANGUAGE, AudioService.DEFAULT_TTS_LANGUAGE)
             ?: AudioService.DEFAULT_TTS_LANGUAGE
         val ttsRate = prefs.getFloat(KEY_TTS_RATE, AudioService.DEFAULT_TTS_RATE)
@@ -261,6 +267,8 @@ class SettingsActivity : AppCompatActivity() {
         whisperModelDropdown.setText(whisperModel, false)
         unlockPasswordInput.setText(unlockPassword)
         responseTimeoutInput.setText((responseTimeout / 1000).toString())
+        vncPortInput.setText(vncPort.toString())
+        vncPasswordInput.setText(vncPassword)
         ttsLanguageInput.setText(ttsLanguage)
         ttsRateInput.setText(ttsRate.toString())
         ttsPitchInput.setText(ttsPitch.toString())
@@ -337,6 +345,8 @@ class SettingsActivity : AppCompatActivity() {
         val whisperModel = whisperModelDropdown.text.toString().trim()
         val unlockPassword = unlockPasswordInput.text.toString()
         val timeoutText = responseTimeoutInput.text.toString().trim()
+        val vncPortText = vncPortInput.text.toString().trim()
+        val vncPassword = vncPasswordInput.text.toString()
         val ttsLanguage = ttsLanguageInput.text.toString().trim()
         val ttsRateText = ttsRateInput.text.toString().trim()
         val ttsPitchText = ttsPitchInput.text.toString().trim()
@@ -379,6 +389,13 @@ class SettingsActivity : AppCompatActivity() {
             return
         }
 
+        val vncPort = try {
+            vncPortText.toInt()
+        } catch (e: NumberFormatException) {
+            Toast.makeText(this, getString(R.string.invalid_vnc_port_error), Toast.LENGTH_SHORT).show()
+            return
+        }
+
         val rate = try {
             ttsRateText.toFloat().also {
                 if (it < 0.1f || it > 2.0f) {
@@ -415,6 +432,8 @@ class SettingsActivity : AppCompatActivity() {
             putString(KEY_WHISPER_MODEL, whisperModel)
             putString(KEY_UNLOCK_PASSWORD, unlockPassword)
             putInt(KEY_RESPONSE_TIMEOUT, timeout)
+            putInt(VncPreferences.KEY_VNC_PORT, vncPort)
+            putString(VncPreferences.KEY_VNC_PASSWORD, vncPassword)
             putString(KEY_TTS_LANGUAGE, ttsLanguage)
             putFloat(KEY_TTS_RATE, rate)
             putFloat(KEY_TTS_PITCH, pitch)

--- a/app/src/main/java/com/example/myapplication/VncApiClient.kt
+++ b/app/src/main/java/com/example/myapplication/VncApiClient.kt
@@ -1,0 +1,89 @@
+package com.example.myapplication
+
+import com.google.gson.Gson
+import com.google.gson.JsonSyntaxException
+import com.google.gson.annotations.SerializedName
+import okhttp3.MediaType.Companion.toMediaTypeOrNull
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import okhttp3.RequestBody.Companion.toRequestBody
+
+data class VncInfo(
+    val enabled: Boolean = false,
+    val running: Boolean = false,
+    val pid: Int? = null,
+    val host: String? = null,
+    val port: Int? = null,
+    val display: String? = null,
+    @SerializedName("localhost_only")
+    val localhostOnly: Boolean? = null
+)
+
+data class VncStatusResponse(
+    val status: String? = null,
+    val vnc: VncInfo? = null
+)
+
+data class VncApiResult<T>(
+    val data: T? = null,
+    val error: String? = null,
+    val httpCode: Int? = null
+)
+
+class VncApiClient(
+    private val baseUrl: String,
+    private val client: OkHttpClient = NetworkUtils.createTrustAllClient()
+) {
+    private val gson = Gson()
+
+    fun fetchHealth(): VncApiResult<VncStatusResponse> {
+        return executeRequest("$baseUrl/health", "GET")
+    }
+
+    fun fetchStatus(): VncApiResult<VncStatusResponse> {
+        return executeRequest("$baseUrl/vnc/status", "GET")
+    }
+
+    fun startVnc(): VncApiResult<VncStatusResponse> {
+        return executeRequest("$baseUrl/vnc/start", "POST")
+    }
+
+    fun stopVnc(): VncApiResult<VncStatusResponse> {
+        return executeRequest("$baseUrl/vnc/stop", "POST")
+    }
+
+    private fun executeRequest(url: String, method: String): VncApiResult<VncStatusResponse> {
+        val requestBuilder = Request.Builder().url(url)
+        if (method == "POST") {
+            val emptyBody = "".toRequestBody("application/json".toMediaTypeOrNull())
+            requestBuilder.post(emptyBody)
+        }
+        val request = requestBuilder.build()
+        return try {
+            client.newCall(request).execute().use { response ->
+                val responseBody = response.body?.string().orEmpty()
+                if (!response.isSuccessful) {
+                    return VncApiResult(
+                        error = "HTTP ${response.code}",
+                        httpCode = response.code
+                    )
+                }
+                val parsed = try {
+                    gson.fromJson(responseBody, VncStatusResponse::class.java)
+                } catch (e: JsonSyntaxException) {
+                    null
+                }
+                if (parsed == null) {
+                    VncApiResult(
+                        error = "Respuesta inválida del servidor",
+                        httpCode = response.code
+                    )
+                } else {
+                    VncApiResult(data = parsed, httpCode = response.code)
+                }
+            }
+        } catch (e: Exception) {
+            VncApiResult(error = e.message ?: "Error de red")
+        }
+    }
+}

--- a/app/src/main/java/com/example/myapplication/VncConnectionActivity.kt
+++ b/app/src/main/java/com/example/myapplication/VncConnectionActivity.kt
@@ -1,13 +1,10 @@
 package com.example.myapplication
 
-import android.content.ActivityNotFoundException
 import android.content.Context
 import android.content.Intent
-import android.net.Uri
 import android.os.Bundle
 import android.view.View
 import android.widget.TextView
-import android.widget.Toast
 import androidx.appcompat.app.AlertDialog
 import androidx.appcompat.app.AppCompatActivity
 import androidx.lifecycle.lifecycleScope
@@ -241,18 +238,12 @@ class VncConnectionActivity : AppCompatActivity() {
         val vncHost = resolveVncHost(vncInfo)
         val vncPort = vncInfo?.port ?: vncPortInput.text?.toString()?.toIntOrNull() ?: DEFAULT_VNC_PORT
         val password = vncPasswordInput.text?.toString().orEmpty()
-
-        val uri = if (password.isNotBlank()) {
-            Uri.parse("vnc://$password@$vncHost:$vncPort")
-        } else {
-            Uri.parse("vnc://$vncHost:$vncPort")
+        val intent = Intent(this, VncStreamActivity::class.java).apply {
+            putExtra(VncStreamActivity.EXTRA_HOST, vncHost)
+            putExtra(VncStreamActivity.EXTRA_PORT, vncPort)
+            putExtra(VncStreamActivity.EXTRA_PASSWORD, password)
         }
-
-        try {
-            startActivity(Intent(Intent.ACTION_VIEW, uri))
-        } catch (e: ActivityNotFoundException) {
-            Toast.makeText(this, R.string.vnc_client_missing, Toast.LENGTH_LONG).show()
-        }
+        startActivity(intent)
     }
 
     private fun updateUiLoading(loading: Boolean) {

--- a/app/src/main/java/com/example/myapplication/VncConnectionActivity.kt
+++ b/app/src/main/java/com/example/myapplication/VncConnectionActivity.kt
@@ -82,16 +82,20 @@ class VncConnectionActivity : AppCompatActivity() {
             serverPrefs.getInt(AudioService.KEY_SERVER_PORT, AudioService.DEFAULT_SERVER_PORT).toString()
         )
 
-        val vncPrefs = getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
-        vncPortInput.setText(vncPrefs.getInt(KEY_VNC_PORT, DEFAULT_VNC_PORT).toString())
-        vncPasswordInput.setText(vncPrefs.getString(KEY_VNC_PASSWORD, ""))
+        vncPortInput.setText(
+            serverPrefs.getInt(VncPreferences.KEY_VNC_PORT, VncPreferences.DEFAULT_VNC_PORT).toString()
+        )
+        vncPasswordInput.setText(serverPrefs.getString(VncPreferences.KEY_VNC_PASSWORD, ""))
     }
 
     private fun savePreferences() {
-        val vncPrefs = getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+        val vncPrefs = getSharedPreferences(AudioService.PREFS_NAME, Context.MODE_PRIVATE)
         vncPrefs.edit()
-            .putInt(KEY_VNC_PORT, vncPortInput.text?.toString()?.toIntOrNull() ?: DEFAULT_VNC_PORT)
-            .putString(KEY_VNC_PASSWORD, vncPasswordInput.text?.toString().orEmpty())
+            .putInt(
+                VncPreferences.KEY_VNC_PORT,
+                vncPortInput.text?.toString()?.toIntOrNull() ?: VncPreferences.DEFAULT_VNC_PORT
+            )
+            .putString(VncPreferences.KEY_VNC_PASSWORD, vncPasswordInput.text?.toString().orEmpty())
             .apply()
     }
 
@@ -236,7 +240,9 @@ class VncConnectionActivity : AppCompatActivity() {
     private fun openVncStream() {
         val vncInfo = latestVncInfo
         val vncHost = resolveVncHost(vncInfo)
-        val vncPort = vncInfo?.port ?: vncPortInput.text?.toString()?.toIntOrNull() ?: DEFAULT_VNC_PORT
+        val vncPort = vncInfo?.port
+            ?: vncPortInput.text?.toString()?.toIntOrNull()
+            ?: VncPreferences.DEFAULT_VNC_PORT
         val password = vncPasswordInput.text?.toString().orEmpty()
         val intent = Intent(this, VncStreamActivity::class.java).apply {
             putExtra(VncStreamActivity.EXTRA_HOST, vncHost)
@@ -267,7 +273,7 @@ class VncConnectionActivity : AppCompatActivity() {
             R.string.vnc_status_summary,
             runningText,
             resolvedHost,
-            vncInfo.port ?: DEFAULT_VNC_PORT,
+            vncInfo.port ?: VncPreferences.DEFAULT_VNC_PORT,
             vncInfo.display ?: "--"
         )
     }
@@ -292,10 +298,6 @@ class VncConnectionActivity : AppCompatActivity() {
     )
 
     companion object {
-        private const val PREFS_NAME = "VncPreferences"
-        private const val KEY_VNC_PORT = "vnc_port"
-        private const val KEY_VNC_PASSWORD = "vnc_password"
-        private const val DEFAULT_VNC_PORT = 5901
         private const val REFRESH_INTERVAL_MS = 10_000L
     }
 }

--- a/app/src/main/java/com/example/myapplication/VncConnectionActivity.kt
+++ b/app/src/main/java/com/example/myapplication/VncConnectionActivity.kt
@@ -1,0 +1,239 @@
+package com.example.myapplication
+
+import android.content.ActivityNotFoundException
+import android.content.Context
+import android.content.Intent
+import android.net.Uri
+import android.os.Bundle
+import android.view.View
+import android.widget.TextView
+import android.widget.Toast
+import androidx.appcompat.app.AlertDialog
+import androidx.appcompat.app.AppCompatActivity
+import androidx.lifecycle.lifecycleScope
+import com.google.android.material.appbar.MaterialToolbar
+import com.google.android.material.button.MaterialButton
+import com.google.android.material.textfield.TextInputEditText
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+
+class VncConnectionActivity : AppCompatActivity() {
+    private lateinit var serverHostInput: TextInputEditText
+    private lateinit var serverPortInput: TextInputEditText
+    private lateinit var vncPortInput: TextInputEditText
+    private lateinit var vncPasswordInput: TextInputEditText
+    private lateinit var statusText: TextView
+    private lateinit var btnConnect: MaterialButton
+    private lateinit var btnOpenStream: MaterialButton
+    private lateinit var btnStopVnc: MaterialButton
+
+    private var latestVncInfo: VncInfo? = null
+    private var latestServerHost: String = ""
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(R.layout.activity_vnc_connection)
+
+        findViewById<MaterialToolbar>(R.id.vncToolbar).setNavigationOnClickListener {
+            finish()
+        }
+
+        bindViews()
+        loadPreferences()
+        setupActions()
+    }
+
+    private fun bindViews() {
+        serverHostInput = findViewById(R.id.vncServerHostInput)
+        serverPortInput = findViewById(R.id.vncServerPortInput)
+        vncPortInput = findViewById(R.id.vncPortInput)
+        vncPasswordInput = findViewById(R.id.vncPasswordInput)
+        statusText = findViewById(R.id.vncStatusText)
+        btnConnect = findViewById(R.id.btnVncConnect)
+        btnOpenStream = findViewById(R.id.btnVncOpenStream)
+        btnStopVnc = findViewById(R.id.btnVncStop)
+    }
+
+    private fun setupActions() {
+        btnConnect.setOnClickListener { performConnectionFlow() }
+        btnOpenStream.setOnClickListener { openVncStream() }
+        btnStopVnc.setOnClickListener { stopVncServer() }
+    }
+
+    private fun loadPreferences() {
+        val serverPrefs = getSharedPreferences(AudioService.PREFS_NAME, Context.MODE_PRIVATE)
+        serverHostInput.setText(
+            serverPrefs.getString(AudioService.KEY_SERVER_IP, AudioService.DEFAULT_SERVER_IP)
+        )
+        serverPortInput.setText(
+            serverPrefs.getInt(AudioService.KEY_SERVER_PORT, AudioService.DEFAULT_SERVER_PORT).toString()
+        )
+
+        val vncPrefs = getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+        vncPortInput.setText(vncPrefs.getInt(KEY_VNC_PORT, DEFAULT_VNC_PORT).toString())
+        vncPasswordInput.setText(vncPrefs.getString(KEY_VNC_PASSWORD, ""))
+    }
+
+    private fun savePreferences() {
+        val vncPrefs = getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+        vncPrefs.edit()
+            .putInt(KEY_VNC_PORT, vncPortInput.text?.toString()?.toIntOrNull() ?: DEFAULT_VNC_PORT)
+            .putString(KEY_VNC_PASSWORD, vncPasswordInput.text?.toString().orEmpty())
+            .apply()
+    }
+
+    private fun performConnectionFlow() {
+        savePreferences()
+        updateUiLoading(true)
+
+        val serverHost = serverHostInput.text?.toString()?.trim().orEmpty()
+        val serverPort = serverPortInput.text?.toString()?.trim().orEmpty()
+        if (serverHost.isBlank() || serverPort.isBlank()) {
+            updateStatus(getString(R.string.vnc_missing_server_info))
+            updateUiLoading(false)
+            return
+        }
+
+        latestServerHost = serverHost
+        val baseUrl = "https://$serverHost:$serverPort"
+        val apiClient = VncApiClient(baseUrl)
+
+        lifecycleScope.launch {
+            val healthResult = withContext(Dispatchers.IO) { apiClient.fetchHealth() }
+            if (healthResult.error != null) {
+                updateStatus(getString(R.string.vnc_health_failed, healthResult.error))
+                updateUiLoading(false)
+                return@launch
+            }
+            val statusResult = withContext(Dispatchers.IO) { apiClient.fetchStatus() }
+            if (statusResult.error != null) {
+                updateStatus(getString(R.string.vnc_status_failed, statusResult.error))
+                updateUiLoading(false)
+                return@launch
+            }
+            val vncInfo = statusResult.data?.vnc
+            latestVncInfo = vncInfo
+            if (vncInfo == null) {
+                updateStatus(getString(R.string.vnc_status_unavailable))
+                updateUiLoading(false)
+                return@launch
+            }
+
+            if (!vncInfo.running && vncInfo.enabled) {
+                updateUiLoading(false)
+                promptStartVnc(apiClient)
+            } else {
+                updateStatus(formatStatus(vncInfo))
+                updateUiLoading(false)
+                updateStreamButtons(vncInfo.running)
+            }
+        }
+    }
+
+    private fun promptStartVnc(apiClient: VncApiClient) {
+        AlertDialog.Builder(this)
+            .setTitle(R.string.vnc_start_prompt_title)
+            .setMessage(R.string.vnc_start_prompt_message)
+            .setPositiveButton(R.string.vnc_start_confirm) { _, _ ->
+                lifecycleScope.launch {
+                    updateUiLoading(true)
+                    val startResult = withContext(Dispatchers.IO) { apiClient.startVnc() }
+                    if (startResult.error != null) {
+                        updateStatus(getString(R.string.vnc_start_failed, startResult.error))
+                        updateUiLoading(false)
+                        return@launch
+                    }
+                    val vncInfo = startResult.data?.vnc
+                    latestVncInfo = vncInfo
+                    updateStatus(formatStatus(vncInfo))
+                    updateUiLoading(false)
+                    updateStreamButtons(vncInfo?.running == true)
+                }
+            }
+            .setNegativeButton(android.R.string.cancel) { _, _ ->
+                updateStatus(getString(R.string.vnc_start_cancelled))
+                updateStreamButtons(false)
+            }
+            .show()
+    }
+
+    private fun stopVncServer() {
+        val serverHost = serverHostInput.text?.toString()?.trim().orEmpty()
+        val serverPort = serverPortInput.text?.toString()?.trim().orEmpty()
+        if (serverHost.isBlank() || serverPort.isBlank()) {
+            updateStatus(getString(R.string.vnc_missing_server_info))
+            return
+        }
+        val apiClient = VncApiClient("https://$serverHost:$serverPort")
+        lifecycleScope.launch {
+            updateUiLoading(true)
+            val stopResult = withContext(Dispatchers.IO) { apiClient.stopVnc() }
+            if (stopResult.error != null) {
+                updateStatus(getString(R.string.vnc_stop_failed, stopResult.error))
+                updateUiLoading(false)
+                return@launch
+            }
+            latestVncInfo = stopResult.data?.vnc
+            updateStatus(getString(R.string.vnc_stopped))
+            updateUiLoading(false)
+            updateStreamButtons(false)
+        }
+    }
+
+    private fun openVncStream() {
+        val vncInfo = latestVncInfo
+        val vncHost = vncInfo?.host?.takeIf { it.isNotBlank() } ?: latestServerHost
+        val vncPort = vncInfo?.port ?: vncPortInput.text?.toString()?.toIntOrNull() ?: DEFAULT_VNC_PORT
+        val password = vncPasswordInput.text?.toString().orEmpty()
+
+        val uri = if (password.isNotBlank()) {
+            Uri.parse("vnc://$password@$vncHost:$vncPort")
+        } else {
+            Uri.parse("vnc://$vncHost:$vncPort")
+        }
+
+        try {
+            startActivity(Intent(Intent.ACTION_VIEW, uri))
+        } catch (e: ActivityNotFoundException) {
+            Toast.makeText(this, R.string.vnc_client_missing, Toast.LENGTH_LONG).show()
+        }
+    }
+
+    private fun updateUiLoading(loading: Boolean) {
+        btnConnect.isEnabled = !loading
+        btnStopVnc.isEnabled = !loading
+        btnOpenStream.isEnabled = !loading && (latestVncInfo?.running == true)
+        statusText.visibility = View.VISIBLE
+    }
+
+    private fun updateStatus(message: String) {
+        statusText.text = message
+    }
+
+    private fun formatStatus(vncInfo: VncInfo?): String {
+        if (vncInfo == null) {
+            return getString(R.string.vnc_status_unavailable)
+        }
+        val runningText = if (vncInfo.running) getString(R.string.vnc_status_running) else getString(R.string.vnc_status_stopped)
+        return getString(
+            R.string.vnc_status_summary,
+            runningText,
+            vncInfo.host ?: latestServerHost,
+            vncInfo.port ?: DEFAULT_VNC_PORT,
+            vncInfo.display ?: "--"
+        )
+    }
+
+    private fun updateStreamButtons(running: Boolean) {
+        btnOpenStream.isEnabled = running
+        btnStopVnc.isEnabled = running
+    }
+
+    companion object {
+        private const val PREFS_NAME = "VncPreferences"
+        private const val KEY_VNC_PORT = "vnc_port"
+        private const val KEY_VNC_PASSWORD = "vnc_password"
+        private const val DEFAULT_VNC_PORT = 5901
+    }
+}

--- a/app/src/main/java/com/example/myapplication/VncConnectionActivity.kt
+++ b/app/src/main/java/com/example/myapplication/VncConnectionActivity.kt
@@ -238,7 +238,7 @@ class VncConnectionActivity : AppCompatActivity() {
 
     private fun openVncStream() {
         val vncInfo = latestVncInfo
-        val vncHost = vncInfo?.host?.takeIf { it.isNotBlank() } ?: latestServerHost
+        val vncHost = resolveVncHost(vncInfo)
         val vncPort = vncInfo?.port ?: vncPortInput.text?.toString()?.toIntOrNull() ?: DEFAULT_VNC_PORT
         val password = vncPasswordInput.text?.toString().orEmpty()
 
@@ -271,10 +271,11 @@ class VncConnectionActivity : AppCompatActivity() {
             return getString(R.string.vnc_status_unavailable)
         }
         val runningText = if (vncInfo.running) getString(R.string.vnc_status_running) else getString(R.string.vnc_status_stopped)
+        val resolvedHost = resolveVncHost(vncInfo)
         return getString(
             R.string.vnc_status_summary,
             runningText,
-            vncInfo.host ?: latestServerHost,
+            resolvedHost,
             vncInfo.port ?: DEFAULT_VNC_PORT,
             vncInfo.display ?: "--"
         )
@@ -283,6 +284,15 @@ class VncConnectionActivity : AppCompatActivity() {
     private fun updateStreamButtons(running: Boolean) {
         btnOpenStream.isEnabled = running
         btnStopVnc.isEnabled = running
+    }
+
+    private fun resolveVncHost(vncInfo: VncInfo?): String {
+        val advertisedHost = vncInfo?.host?.trim().orEmpty()
+        return if (advertisedHost.isBlank() || advertisedHost == "0.0.0.0") {
+            latestServerHost
+        } else {
+            advertisedHost
+        }
     }
 
     private data class ServerConfig(

--- a/app/src/main/java/com/example/myapplication/VncPreferences.kt
+++ b/app/src/main/java/com/example/myapplication/VncPreferences.kt
@@ -1,0 +1,8 @@
+package com.example.myapplication
+
+object VncPreferences {
+    const val KEY_VNC_PORT = "vnc_port"
+    const val KEY_VNC_PASSWORD = "vnc_password"
+    const val KEY_VNC_MODE_ENABLED = "vnc_mode_enabled"
+    const val DEFAULT_VNC_PORT = 5901
+}

--- a/app/src/main/java/com/example/myapplication/VncStreamActivity.kt
+++ b/app/src/main/java/com/example/myapplication/VncStreamActivity.kt
@@ -1,0 +1,108 @@
+package com.example.myapplication
+
+import android.os.Bundle
+import android.view.View
+import android.widget.FrameLayout
+import android.widget.TextView
+import android.widget.Toast
+import androidx.appcompat.app.AppCompatActivity
+import com.google.android.material.appbar.MaterialToolbar
+
+class VncStreamActivity : AppCompatActivity() {
+    private lateinit var container: FrameLayout
+    private lateinit var statusText: TextView
+    private var vncViewInstance: Any? = null
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(R.layout.activity_vnc_stream)
+
+        findViewById<MaterialToolbar>(R.id.vncStreamToolbar).setNavigationOnClickListener {
+            finish()
+        }
+
+        container = findViewById(R.id.vncStreamContainer)
+        statusText = findViewById(R.id.vncStreamStatus)
+
+        val host = intent.getStringExtra(EXTRA_HOST).orEmpty()
+        val port = intent.getIntExtra(EXTRA_PORT, DEFAULT_VNC_PORT)
+        val password = intent.getStringExtra(EXTRA_PASSWORD).orEmpty()
+
+        if (host.isBlank()) {
+            showError(getString(R.string.vnc_stream_missing_host))
+            return
+        }
+
+        connectVnc(host, port, password)
+    }
+
+    override fun onDestroy() {
+        super.onDestroy()
+        shutdownVnc()
+    }
+
+    private fun connectVnc(host: String, port: Int, password: String) {
+        statusText.text = getString(R.string.vnc_stream_connecting, host, port)
+        try {
+            val viewClass = Class.forName("android.vnc.VncCanvasView")
+            val view = viewClass.getConstructor(android.content.Context::class.java).newInstance(this)
+            vncViewInstance = view
+            container.addView(view as View)
+
+            invokeIfExists(view, "setConnectionInfo", arrayOf(String::class.java, Int::class.java, String::class.java), host, port, password)
+            invokeIfExists(view, "setHost", arrayOf(String::class.java), host)
+            invokeIfExists(view, "setPort", arrayOf(Int::class.java), port)
+            if (password.isNotBlank()) {
+                invokeIfExists(view, "setPassword", arrayOf(String::class.java), password)
+            }
+
+            val started = invokeIfExists(view, "connect", emptyArray()) ||
+                invokeIfExists(view, "startConnection", emptyArray())
+
+            if (!started) {
+                statusText.text = getString(R.string.vnc_stream_connected)
+            }
+        } catch (e: ClassNotFoundException) {
+            showError(getString(R.string.vnc_stream_missing_library))
+        } catch (e: Exception) {
+            showError(getString(R.string.vnc_stream_failed, e.message ?: "Error"))
+        }
+    }
+
+    private fun shutdownVnc() {
+        vncViewInstance?.let { view ->
+            invokeIfExists(view, "shutdown", emptyArray())
+            invokeIfExists(view, "disconnect", emptyArray())
+        }
+        vncViewInstance = null
+    }
+
+    private fun invokeIfExists(
+        target: Any,
+        methodName: String,
+        parameterTypes: Array<Class<*>>,
+        vararg args: Any
+    ): Boolean {
+        return try {
+            val method = target.javaClass.getMethod(methodName, *parameterTypes)
+            method.invoke(target, *args)
+            true
+        } catch (e: NoSuchMethodException) {
+            false
+        } catch (e: Exception) {
+            false
+        }
+    }
+
+    private fun showError(message: String) {
+        statusText.text = message
+        Toast.makeText(this, message, Toast.LENGTH_LONG).show()
+    }
+
+    companion object {
+        const val EXTRA_HOST = "extra_vnc_host"
+        const val EXTRA_PORT = "extra_vnc_port"
+        const val EXTRA_PASSWORD = "extra_vnc_password"
+        private const val DEFAULT_VNC_PORT = 5901
+    }
+}

--- a/app/src/main/java/com/example/myapplication/VncStreamActivity.kt
+++ b/app/src/main/java/com/example/myapplication/VncStreamActivity.kt
@@ -6,13 +6,11 @@ import android.widget.TextView
 import android.widget.Toast
 import androidx.appcompat.app.AppCompatActivity
 import com.google.android.material.appbar.MaterialToolbar
-import com.google.android.material.dialog.MaterialAlertDialogBuilder
 
 class VncStreamActivity : AppCompatActivity() {
     private lateinit var container: FrameLayout
     private lateinit var statusText: TextView
-    private var vncViewInstance: Any? = null
-    private var connectionInfo: ConnectionInfo? = null
+    private var vncViewInstance: android.vnc.VncCanvasView? = null
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -28,8 +26,6 @@ class VncStreamActivity : AppCompatActivity() {
         val host = intent.getStringExtra(EXTRA_HOST).orEmpty()
         val port = intent.getIntExtra(EXTRA_PORT, DEFAULT_VNC_PORT)
         val password = intent.getStringExtra(EXTRA_PASSWORD).orEmpty()
-        connectionInfo = ConnectionInfo(host, port, password)
-
         if (host.isBlank()) {
             showError(getString(R.string.vnc_stream_missing_host))
             return
@@ -37,6 +33,7 @@ class VncStreamActivity : AppCompatActivity() {
 
         connectVnc(host, port, password)
     }
+
 
     override fun onDestroy() {
         super.onDestroy()
@@ -46,26 +43,17 @@ class VncStreamActivity : AppCompatActivity() {
     private fun connectVnc(host: String, port: Int, password: String) {
         statusText.text = getString(R.string.vnc_stream_connecting, host, port)
         try {
-            val viewClass = Class.forName("android.vnc.VncCanvasView")
-            val view = viewClass.getConstructor(android.content.Context::class.java).newInstance(this)
+            val view = android.vnc.VncCanvasView(this)
             vncViewInstance = view
-            container.addView(view as android.view.View)
-
-            invokeIfExists(view, "setConnectionInfo", arrayOf(String::class.java, Int::class.java, String::class.java), host, port, password)
-            invokeIfExists(view, "setHost", arrayOf(String::class.java), host)
-            invokeIfExists(view, "setPort", arrayOf(Int::class.java), port)
+            container.addView(view)
+            view.setConnectionInfo(host, port, password)
+            view.setHost(host)
+            view.setPort(port)
             if (password.isNotBlank()) {
-                invokeIfExists(view, "setPassword", arrayOf(String::class.java), password)
+                view.setPassword(password)
             }
-
-            val started = invokeIfExists(view, "connect", emptyArray()) ||
-                invokeIfExists(view, "startConnection", emptyArray())
-
-            if (!started) {
-                statusText.text = getString(R.string.vnc_stream_connected)
-            }
-        } catch (e: ClassNotFoundException) {
-            showMissingViewerDialog()
+            view.connect()
+            statusText.text = getString(R.string.vnc_stream_connected)
         } catch (e: Exception) {
             showError(getString(R.string.vnc_stream_failed, e.message ?: "Error"))
         }
@@ -73,27 +61,10 @@ class VncStreamActivity : AppCompatActivity() {
 
     private fun shutdownVnc() {
         vncViewInstance?.let { view ->
-            invokeIfExists(view, "shutdown", emptyArray())
-            invokeIfExists(view, "disconnect", emptyArray())
+            view.shutdown()
+            view.disconnect()
         }
         vncViewInstance = null
-    }
-
-    private fun invokeIfExists(
-        target: Any,
-        methodName: String,
-        parameterTypes: Array<Class<*>>,
-        vararg args: Any
-    ): Boolean {
-        return try {
-            val method = target.javaClass.getMethod(methodName, *parameterTypes)
-            method.invoke(target, *args)
-            true
-        } catch (e: NoSuchMethodException) {
-            false
-        } catch (e: Exception) {
-            false
-        }
     }
 
     private fun showError(message: String) {
@@ -101,38 +72,6 @@ class VncStreamActivity : AppCompatActivity() {
         Toast.makeText(this, message, Toast.LENGTH_LONG).show()
     }
 
-    private fun showMissingViewerDialog() {
-        statusText.text = getString(R.string.vnc_stream_missing_library)
-        MaterialAlertDialogBuilder(this)
-            .setTitle(R.string.vnc_stream_missing_title)
-            .setMessage(R.string.vnc_stream_missing_body)
-            .setPositiveButton(R.string.vnc_stream_open_external) { _, _ ->
-                openExternalVncClient()
-            }
-            .setNegativeButton(android.R.string.cancel, null)
-            .show()
-    }
-
-    private fun openExternalVncClient() {
-        val info = connectionInfo ?: return
-        val uri = if (info.password.isNotBlank()) {
-            android.net.Uri.parse("vnc://${info.password}@${info.host}:${info.port}")
-        } else {
-            android.net.Uri.parse("vnc://${info.host}:${info.port}")
-        }
-        val intent = android.content.Intent(android.content.Intent.ACTION_VIEW, uri)
-        if (intent.resolveActivity(packageManager) != null) {
-            startActivity(intent)
-        } else {
-            showError(getString(R.string.vnc_client_missing))
-        }
-    }
-
-    private data class ConnectionInfo(
-        val host: String,
-        val port: Int,
-        val password: String
-    )
 
     companion object {
         const val EXTRA_HOST = "extra_vnc_host"

--- a/app/src/main/res/layout-land/activity_main.xml
+++ b/app/src/main/res/layout-land/activity_main.xml
@@ -232,6 +232,13 @@
                             android:text="@string/screenshots_title"
                             android:textAppearance="?attr/textAppearanceTitleMedium" />
 
+                        <com.google.android.material.switchmaterial.SwitchMaterial
+                            android:id="@+id/switchVncMode"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:layout_marginEnd="8dp"
+                            android:text="@string/vnc_toggle_live" />
+
                         <com.google.android.material.button.MaterialButton
                             android:id="@+id/btnRefreshPeriod"
                             style="@style/Widget.Material3.Button.TextButton"
@@ -294,11 +301,19 @@
                     <ImageView
                         android:id="@+id/screenshotImageView"
                         android:layout_width="match_parent"
-                        android:layout_height="250dp"
+                        android:layout_height="@dimen/visual_surface_height"
                         android:adjustViewBounds="true"
                         android:background="@color/md_theme_surfaceVariant"
                         android:contentDescription="@string/remote_screenshot"
                         android:scaleType="centerCrop" />
+
+                    <FrameLayout
+                        android:id="@+id/vncStreamContainerMain"
+                        android:layout_width="match_parent"
+                        android:layout_height="@dimen/visual_surface_height"
+                        android:layout_marginTop="4dp"
+                        android:visibility="gone"
+                        android:background="@color/md_theme_surfaceVariant" />
 
                 </LinearLayout>
             </com.google.android.material.card.MaterialCardView>

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -198,7 +198,7 @@
                 android:id="@+id/screenshotCard"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:layout_marginTop="8dp"
+                android:layout_marginTop="4dp"
                 android:clickable="true"
                 android:focusable="true"
                 app:cardElevation="2dp"
@@ -215,8 +215,8 @@
                     android:orientation="vertical"
                     android:paddingStart="16dp"
                     android:paddingEnd="16dp"
-                    android:paddingTop="12dp"
-                    android:paddingBottom="12dp">
+                    android:paddingTop="8dp"
+                    android:paddingBottom="8dp">
 
                     <LinearLayout
                         android:layout_width="match_parent"

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -228,6 +228,13 @@
                             android:text="@string/screenshots_title"
                             android:textAppearance="?attr/textAppearanceTitleMedium" />
 
+                        <com.google.android.material.switchmaterial.SwitchMaterial
+                            android:id="@+id/switchVncMode"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:layout_marginEnd="8dp"
+                            android:text="@string/vnc_toggle_live" />
+
                         <com.google.android.material.button.MaterialButton
                             android:id="@+id/btnRefreshPeriod"
                             style="@style/Widget.Material3.Button.TextButton"
@@ -297,6 +304,14 @@
                         android:contentDescription="@string/remote_screenshot"
                         android:scaleType="fitCenter"
                         android:padding="4dp" />
+
+                    <FrameLayout
+                        android:id="@+id/vncStreamContainerMain"
+                        android:layout_width="match_parent"
+                        android:layout_height="200dp"
+                        android:layout_marginTop="4dp"
+                        android:visibility="gone"
+                        android:background="@color/md_theme_surfaceVariant" />
 
                 </LinearLayout>
             </com.google.android.material.card.MaterialCardView>

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -213,7 +213,10 @@
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:orientation="vertical"
-                    android:padding="16dp">
+                    android:paddingStart="16dp"
+                    android:paddingEnd="16dp"
+                    android:paddingTop="12dp"
+                    android:paddingBottom="12dp">
 
                     <LinearLayout
                         android:layout_width="match_parent"
@@ -278,7 +281,7 @@
                         android:id="@+id/screenshotStatusText"
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content"
-                        android:layout_marginTop="8dp"
+                        android:layout_marginTop="4dp"
                         android:text="@string/no_screenshots_available"
                         android:textAppearance="?attr/textAppearanceBodySmall"
                         android:textStyle="italic" />
@@ -289,7 +292,7 @@
                         style="@style/Widget.AppCompat.ProgressBar.Horizontal"
                         android:layout_width="match_parent"
                         android:layout_height="4dp"
-                        android:layout_marginTop="8dp"
+                        android:layout_marginTop="4dp"
                         android:visibility="gone"
                         android:indeterminate="true"
                         android:progressTint="?attr/colorPrimary" />

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -297,7 +297,7 @@
                     <ImageView
                         android:id="@+id/screenshotImageView"
                         android:layout_width="match_parent"
-                        android:layout_height="200dp"
+                        android:layout_height="@dimen/visual_surface_height"
                         android:layout_marginTop="4dp"
                         android:adjustViewBounds="true"
                         android:background="@color/md_theme_surfaceVariant"
@@ -308,7 +308,7 @@
                     <FrameLayout
                         android:id="@+id/vncStreamContainerMain"
                         android:layout_width="match_parent"
-                        android:layout_height="200dp"
+                        android:layout_height="@dimen/visual_surface_height"
                         android:layout_marginTop="4dp"
                         android:visibility="gone"
                         android:background="@color/md_theme_surfaceVariant" />

--- a/app/src/main/res/layout/activity_settings.xml
+++ b/app/src/main/res/layout/activity_settings.xml
@@ -127,6 +127,44 @@
                             android:maxLines="1" />
                     </com.google.android.material.textfield.TextInputLayout>
 
+                    <TextView
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:layout_marginTop="16dp"
+                        android:text="@string/vnc_settings_title"
+                        android:textAppearance="?attr/textAppearanceTitleSmall"
+                        android:textStyle="bold" />
+
+                    <com.google.android.material.textfield.TextInputLayout
+                        style="@style/Widget.MaterialComponents.TextInputLayout.OutlinedBox"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:layout_marginTop="8dp"
+                        android:hint="@string/vnc_port_hint">
+
+                        <com.google.android.material.textfield.TextInputEditText
+                            android:id="@+id/vncPortInput"
+                            android:layout_width="match_parent"
+                            android:layout_height="wrap_content"
+                            android:inputType="number"
+                            android:maxLines="1" />
+                    </com.google.android.material.textfield.TextInputLayout>
+
+                    <com.google.android.material.textfield.TextInputLayout
+                        style="@style/Widget.MaterialComponents.TextInputLayout.OutlinedBox"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:layout_marginTop="8dp"
+                        android:hint="@string/vnc_password_hint">
+
+                        <com.google.android.material.textfield.TextInputEditText
+                            android:id="@+id/vncPasswordInput"
+                            android:layout_width="match_parent"
+                            android:layout_height="wrap_content"
+                            android:inputType="textPassword"
+                            android:maxLines="1" />
+                    </com.google.android.material.textfield.TextInputLayout>
+
                 </LinearLayout>
             </com.google.android.material.card.MaterialCardView>
 

--- a/app/src/main/res/layout/activity_vnc_connection.xml
+++ b/app/src/main/res/layout/activity_vnc_connection.xml
@@ -1,0 +1,161 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.coordinatorlayout.widget.CoordinatorLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <com.google.android.material.appbar.AppBarLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content">
+
+        <com.google.android.material.appbar.MaterialToolbar
+            android:id="@+id/vncToolbar"
+            android:layout_width="match_parent"
+            android:layout_height="?attr/actionBarSize"
+            android:background="@android:color/transparent"
+            app:navigationIcon="@android:drawable/ic_menu_close_clear_cancel"
+            app:title="@string/vnc_connection_title" />
+    </com.google.android.material.appbar.AppBarLayout>
+
+    <androidx.core.widget.NestedScrollView
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:clipToPadding="false"
+        android:padding="16dp"
+        app:layout_behavior="@string/appbar_scrolling_view_behavior">
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="vertical">
+
+            <com.google.android.material.card.MaterialCardView
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginBottom="12dp"
+                app:cardCornerRadius="12dp"
+                app:cardElevation="2dp">
+
+                <LinearLayout
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:orientation="vertical"
+                    android:padding="16dp">
+
+                    <TextView
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:layout_marginBottom="12dp"
+                        android:text="@string/vnc_connection_section"
+                        android:textAppearance="?attr/textAppearanceTitleMedium"
+                        android:textStyle="bold" />
+
+                    <com.google.android.material.textfield.TextInputLayout
+                        style="@style/Widget.MaterialComponents.TextInputLayout.OutlinedBox"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:hint="@string/server_ip_hint">
+
+                        <com.google.android.material.textfield.TextInputEditText
+                            android:id="@+id/vncServerHostInput"
+                            android:layout_width="match_parent"
+                            android:layout_height="wrap_content"
+                            android:inputType="text"
+                            android:maxLines="1" />
+                    </com.google.android.material.textfield.TextInputLayout>
+
+                    <com.google.android.material.textfield.TextInputLayout
+                        style="@style/Widget.MaterialComponents.TextInputLayout.OutlinedBox"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:layout_marginTop="8dp"
+                        android:hint="@string/server_port_hint">
+
+                        <com.google.android.material.textfield.TextInputEditText
+                            android:id="@+id/vncServerPortInput"
+                            android:layout_width="match_parent"
+                            android:layout_height="wrap_content"
+                            android:inputType="number"
+                            android:maxLines="1" />
+                    </com.google.android.material.textfield.TextInputLayout>
+
+                    <com.google.android.material.textfield.TextInputLayout
+                        style="@style/Widget.MaterialComponents.TextInputLayout.OutlinedBox"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:layout_marginTop="8dp"
+                        android:hint="@string/vnc_port_hint">
+
+                        <com.google.android.material.textfield.TextInputEditText
+                            android:id="@+id/vncPortInput"
+                            android:layout_width="match_parent"
+                            android:layout_height="wrap_content"
+                            android:inputType="number"
+                            android:maxLines="1" />
+                    </com.google.android.material.textfield.TextInputLayout>
+
+                    <com.google.android.material.textfield.TextInputLayout
+                        style="@style/Widget.MaterialComponents.TextInputLayout.OutlinedBox"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:layout_marginTop="8dp"
+                        android:hint="@string/vnc_password_hint">
+
+                        <com.google.android.material.textfield.TextInputEditText
+                            android:id="@+id/vncPasswordInput"
+                            android:layout_width="match_parent"
+                            android:layout_height="wrap_content"
+                            android:inputType="textPassword"
+                            android:maxLines="1" />
+                    </com.google.android.material.textfield.TextInputLayout>
+
+                    <LinearLayout
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:layout_marginTop="12dp"
+                        android:gravity="center_vertical"
+                        android:orientation="horizontal">
+
+                        <com.google.android.material.button.MaterialButton
+                            android:id="@+id/btnVncConnect"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:text="@string/vnc_connect"
+                            app:icon="@android:drawable/ic_menu_send" />
+
+                        <com.google.android.material.button.MaterialButton
+                            android:id="@+id/btnVncStop"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:layout_marginStart="8dp"
+                            android:text="@string/vnc_stop"
+                            app:icon="@android:drawable/ic_media_pause" />
+
+                        <com.google.android.material.button.MaterialButton
+                            android:id="@+id/btnVncOpenStream"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:layout_marginStart="8dp"
+                            android:text="@string/vnc_open_stream"
+                            app:icon="@android:drawable/ic_menu_view" />
+                    </LinearLayout>
+
+                    <TextView
+                        android:id="@+id/vncStatusText"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:layout_marginTop="12dp"
+                        android:textAppearance="?attr/textAppearanceBodyMedium"
+                        android:textColor="?attr/colorOnSurface" />
+                </LinearLayout>
+            </com.google.android.material.card.MaterialCardView>
+
+            <TextView
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:text="@string/vnc_connection_help"
+                android:textAppearance="?attr/textAppearanceBodySmall"
+                android:textColor="?attr/colorOnSurfaceVariant" />
+        </LinearLayout>
+    </androidx.core.widget.NestedScrollView>
+</androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/app/src/main/res/layout/activity_vnc_stream.xml
+++ b/app/src/main/res/layout/activity_vnc_stream.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.coordinatorlayout.widget.CoordinatorLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <com.google.android.material.appbar.AppBarLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content">
+
+        <com.google.android.material.appbar.MaterialToolbar
+            android:id="@+id/vncStreamToolbar"
+            android:layout_width="match_parent"
+            android:layout_height="?attr/actionBarSize"
+            android:background="@android:color/transparent"
+            app:navigationIcon="@android:drawable/ic_menu_close_clear_cancel"
+            app:title="@string/vnc_stream_title" />
+    </com.google.android.material.appbar.AppBarLayout>
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:orientation="vertical"
+        android:padding="16dp"
+        app:layout_behavior="@string/appbar_scrolling_view_behavior">
+
+        <TextView
+            android:id="@+id/vncStreamStatus"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginBottom="8dp"
+            android:textAppearance="?attr/textAppearanceBodyMedium"
+            android:textColor="?attr/colorOnSurface" />
+
+        <FrameLayout
+            android:id="@+id/vncStreamContainer"
+            android:layout_width="match_parent"
+            android:layout_height="0dp"
+            android:layout_weight="1"
+            android:background="?attr/colorSurfaceVariant" />
+    </LinearLayout>
+</androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/app/src/main/res/layout/drawer_content.xml
+++ b/app/src/main/res/layout/drawer_content.xml
@@ -57,6 +57,34 @@
                         android:textColor="?attr/colorOnSurface" />
                 </LinearLayout>
 
+                <!-- VNC Streaming -->
+                <LinearLayout
+                    android:id="@+id/nav_vnc"
+                    android:layout_width="match_parent"
+                    android:layout_height="48dp"
+                    android:orientation="horizontal"
+                    android:gravity="center_vertical"
+                    android:paddingHorizontal="16dp"
+                    android:background="?attr/selectableItemBackground"
+                    android:clickable="true"
+                    android:focusable="true">
+
+                    <ImageView
+                        android:layout_width="24dp"
+                        android:layout_height="24dp"
+                        android:src="@android:drawable/ic_menu_view"
+                        android:contentDescription="@string/vnc_menu_title"
+                        app:tint="?attr/colorOnSurfaceVariant" />
+
+                    <TextView
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_marginStart="16dp"
+                        android:text="@string/vnc_menu_title"
+                        android:textAppearance="?attr/textAppearanceBodyLarge"
+                        android:textColor="?attr/colorOnSurface" />
+                </LinearLayout>
+
                 <!-- Configuración -->
                 <LinearLayout
                     android:id="@+id/nav_settings"
@@ -122,4 +150,3 @@
     <include layout="@layout/drawer_footer" />
 
 </LinearLayout>
-

--- a/app/src/main/res/layout/drawer_content.xml
+++ b/app/src/main/res/layout/drawer_content.xml
@@ -57,34 +57,6 @@
                         android:textColor="?attr/colorOnSurface" />
                 </LinearLayout>
 
-                <!-- VNC Streaming -->
-                <LinearLayout
-                    android:id="@+id/nav_vnc"
-                    android:layout_width="match_parent"
-                    android:layout_height="48dp"
-                    android:orientation="horizontal"
-                    android:gravity="center_vertical"
-                    android:paddingHorizontal="16dp"
-                    android:background="?attr/selectableItemBackground"
-                    android:clickable="true"
-                    android:focusable="true">
-
-                    <ImageView
-                        android:layout_width="24dp"
-                        android:layout_height="24dp"
-                        android:src="@android:drawable/ic_menu_view"
-                        android:contentDescription="@string/vnc_menu_title"
-                        app:tint="?attr/colorOnSurfaceVariant" />
-
-                    <TextView
-                        android:layout_width="wrap_content"
-                        android:layout_height="wrap_content"
-                        android:layout_marginStart="16dp"
-                        android:text="@string/vnc_menu_title"
-                        android:textAppearance="?attr/textAppearanceBodyLarge"
-                        android:textColor="?attr/colorOnSurface" />
-                </LinearLayout>
-
                 <!-- Configuración -->
                 <LinearLayout
                     android:id="@+id/nav_settings"

--- a/app/src/main/res/values-land/dimens.xml
+++ b/app/src/main/res/values-land/dimens.xml
@@ -1,6 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <!-- Drawer footer padding - smaller in landscape -->
-    <dimen name="drawer_footer_padding_bottom">16dp</dimen>
+    <dimen name="visual_surface_height">140dp</dimen>
 </resources>
-

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -2,5 +2,5 @@
 <resources>
     <!-- Drawer footer padding - larger in portrait to avoid system buttons -->
     <dimen name="drawer_footer_padding_bottom">48dp</dimen>
+    <dimen name="visual_surface_height">180dp</dimen>
 </resources>
-

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -189,8 +189,12 @@
     <string name="vnc_connection_title">Conexión VNC</string>
     <string name="vnc_connection_section">Conexión al servidor VNC</string>
     <string name="vnc_connection_help">Primero valida el estado del servidor. Si VNC está habilitado pero detenido, puedes arrancarlo desde aquí. Luego abre un cliente VNC instalado en el dispositivo.</string>
+    <string name="vnc_settings_title">Ajustes VNC</string>
     <string name="vnc_port_hint">Puerto VNC</string>
     <string name="vnc_password_hint">Contraseña VNC</string>
+    <string name="vnc_toggle_live">VNC en vivo</string>
+    <string name="vnc_mode_active">Modo VNC activo</string>
+    <string name="invalid_vnc_port_error">Puerto VNC inválido</string>
     <string name="vnc_connect">Conectar</string>
     <string name="vnc_open_stream">Abrir stream</string>
     <string name="vnc_stop">Detener VNC</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -198,6 +198,7 @@
     <string name="vnc_health_failed">Health falló: %1$s</string>
     <string name="vnc_status_failed">Estado VNC falló: %1$s</string>
     <string name="vnc_status_unavailable">Estado VNC no disponible.</string>
+    <string name="vnc_status_refreshing">Actualizando estado VNC...</string>
     <string name="vnc_start_prompt_title">Arrancar VNC</string>
     <string name="vnc_start_prompt_message">VNC está habilitado pero detenido. ¿Quieres iniciarlo ahora?</string>
     <string name="vnc_start_confirm">Iniciar VNC</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -210,6 +210,12 @@
     <string name="vnc_status_stopped">Detenido</string>
     <string name="vnc_status_summary">Estado: %1$s\nHost: %2$s\nPuerto: %3$d\nDisplay: %4$s</string>
     <string name="vnc_client_missing">No hay un cliente VNC instalado para abrir el stream.</string>
+    <string name="vnc_stream_title">Streaming VNC</string>
+    <string name="vnc_stream_connecting">Conectando a %1$s:%2$d...</string>
+    <string name="vnc_stream_connected">Conexión establecida.</string>
+    <string name="vnc_stream_failed">No se pudo iniciar el stream: %1$s</string>
+    <string name="vnc_stream_missing_host">Host VNC no disponible.</string>
+    <string name="vnc_stream_missing_library">No se pudo cargar el visor VNC embebido.</string>
 
     <!-- MainActivity Messages -->
     <string name="recording_finished_processing">Recording finished, processing...</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -74,6 +74,7 @@
     <string name="timestamp_unavailable">Timestamp no disponible</string>
     <string name="capture_image_description">Captura tomada %1$s</string>
     <string name="tutorial_menu_title">Tutorial</string>
+    <string name="vnc_menu_title">VNC Streaming</string>
     <string name="tutorial_title">Bienvenido</string>
     <string name="tutorial_subtitle">Controla tu ordenador por voz o texto, con lenguaje natural. Da órdenes como las darías a un compañero que maneja un ordenador.</string>
     <string name="tutorial_highlight_title">Tu guía en el primer inicio</string>
@@ -185,6 +186,29 @@
     <string name="summary_status_playing">Reproduciendo</string>
     <string name="summary_status_error">Error al reproducir</string>
     <string name="summary_status_empty">Esperando resumen</string>
+    <string name="vnc_connection_title">Conexión VNC</string>
+    <string name="vnc_connection_section">Conexión al servidor VNC</string>
+    <string name="vnc_connection_help">Primero valida el estado del servidor. Si VNC está habilitado pero detenido, puedes arrancarlo desde aquí. Luego abre un cliente VNC instalado en el dispositivo.</string>
+    <string name="vnc_port_hint">Puerto VNC</string>
+    <string name="vnc_password_hint">Contraseña VNC</string>
+    <string name="vnc_connect">Conectar</string>
+    <string name="vnc_open_stream">Abrir stream</string>
+    <string name="vnc_stop">Detener VNC</string>
+    <string name="vnc_missing_server_info">Introduce host y puerto del servidor.</string>
+    <string name="vnc_health_failed">Health falló: %1$s</string>
+    <string name="vnc_status_failed">Estado VNC falló: %1$s</string>
+    <string name="vnc_status_unavailable">Estado VNC no disponible.</string>
+    <string name="vnc_start_prompt_title">Arrancar VNC</string>
+    <string name="vnc_start_prompt_message">VNC está habilitado pero detenido. ¿Quieres iniciarlo ahora?</string>
+    <string name="vnc_start_confirm">Iniciar VNC</string>
+    <string name="vnc_start_failed">No se pudo iniciar VNC: %1$s</string>
+    <string name="vnc_start_cancelled">Inicio de VNC cancelado.</string>
+    <string name="vnc_stop_failed">No se pudo detener VNC: %1$s</string>
+    <string name="vnc_stopped">VNC detenido.</string>
+    <string name="vnc_status_running">En ejecución</string>
+    <string name="vnc_status_stopped">Detenido</string>
+    <string name="vnc_status_summary">Estado: %1$s\nHost: %2$s\nPuerto: %3$d\nDisplay: %4$s</string>
+    <string name="vnc_client_missing">No hay un cliente VNC instalado para abrir el stream.</string>
 
     <!-- MainActivity Messages -->
     <string name="recording_finished_processing">Recording finished, processing...</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -216,6 +216,9 @@
     <string name="vnc_stream_failed">No se pudo iniciar el stream: %1$s</string>
     <string name="vnc_stream_missing_host">Host VNC no disponible.</string>
     <string name="vnc_stream_missing_library">No se pudo cargar el visor VNC embebido.</string>
+    <string name="vnc_stream_missing_title">Visor VNC no disponible</string>
+    <string name="vnc_stream_missing_body">No se pudo cargar el visor embebido. Puedes abrir un cliente VNC externo si está instalado.</string>
+    <string name="vnc_stream_open_external">Abrir cliente externo</string>
 
     <!-- MainActivity Messages -->
     <string name="recording_finished_processing">Recording finished, processing...</string>

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -16,6 +16,7 @@ dependencyResolutionManagement {
     repositories {
         google()
         mavenCentral()
+        maven(url = "https://jitpack.io")
     }
 }
 

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -16,7 +16,6 @@ dependencyResolutionManagement {
     repositories {
         google()
         mavenCentral()
-        maven(url = "https://jitpack.io")
     }
 }
 

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -21,4 +21,5 @@ dependencyResolutionManagement {
 
 rootProject.name = "Simple Computer Use"
 include(":app")
+include(":vncviewer")
  

--- a/vncviewer/build.gradle.kts
+++ b/vncviewer/build.gradle.kts
@@ -1,0 +1,26 @@
+plugins {
+    id("com.android.library")
+    id("org.jetbrains.kotlin.android")
+}
+
+android {
+    namespace = "android.vnc"
+    compileSdk = 34
+
+    defaultConfig {
+        minSdk = 26
+    }
+
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_1_8
+        targetCompatibility = JavaVersion.VERSION_1_8
+    }
+
+    kotlinOptions {
+        jvmTarget = "1.8"
+    }
+}
+
+dependencies {
+    implementation("androidx.core:core-ktx:1.12.0")
+}

--- a/vncviewer/src/main/AndroidManifest.xml
+++ b/vncviewer/src/main/AndroidManifest.xml
@@ -1,0 +1,2 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest />

--- a/vncviewer/src/main/java/android/vnc/VncCanvasView.kt
+++ b/vncviewer/src/main/java/android/vnc/VncCanvasView.kt
@@ -1,0 +1,63 @@
+package android.vnc
+
+import android.content.Context
+import android.util.AttributeSet
+import android.widget.FrameLayout
+import android.widget.TextView
+
+class VncCanvasView @JvmOverloads constructor(
+    context: Context,
+    attrs: AttributeSet? = null
+) : FrameLayout(context, attrs) {
+    private val statusView = TextView(context)
+    private var host: String = ""
+    private var port: Int = 0
+    private var password: String = ""
+
+    init {
+        statusView.text = "VNC viewer inicializado."
+        addView(statusView)
+    }
+
+    fun setConnectionInfo(host: String, port: Int, password: String) {
+        this.host = host
+        this.port = port
+        this.password = password
+        updateStatus("Preparado para conectar a $host:$port")
+    }
+
+    fun setHost(host: String) {
+        this.host = host
+        updateStatus("Host configurado: $host")
+    }
+
+    fun setPort(port: Int) {
+        this.port = port
+        updateStatus("Puerto configurado: $port")
+    }
+
+    fun setPassword(password: String) {
+        this.password = password
+        updateStatus("Contraseña configurada.")
+    }
+
+    fun connect() {
+        updateStatus("Conexión VNC no implementada en el módulo local.")
+    }
+
+    fun startConnection() {
+        connect()
+    }
+
+    fun disconnect() {
+        updateStatus("Conexión VNC detenida.")
+    }
+
+    fun shutdown() {
+        disconnect()
+    }
+
+    private fun updateStatus(message: String) {
+        statusView.text = message
+    }
+}

--- a/vncviewer/src/main/java/android/vnc/VncCanvasView.kt
+++ b/vncviewer/src/main/java/android/vnc/VncCanvasView.kt
@@ -1,22 +1,51 @@
 package android.vnc
 
 import android.content.Context
+import android.graphics.Bitmap
 import android.util.AttributeSet
+import android.view.Gravity
 import android.widget.FrameLayout
+import android.widget.ImageView
 import android.widget.TextView
+import java.io.BufferedInputStream
+import java.io.BufferedOutputStream
+import java.io.DataInputStream
+import java.io.DataOutputStream
+import java.net.InetSocketAddress
+import java.net.Socket
+import java.nio.ByteBuffer
+import java.nio.ByteOrder
+import java.util.concurrent.atomic.AtomicBoolean
+import javax.crypto.Cipher
+import javax.crypto.spec.SecretKeySpec
 
 class VncCanvasView @JvmOverloads constructor(
     context: Context,
     attrs: AttributeSet? = null
 ) : FrameLayout(context, attrs) {
+    private val imageView = ImageView(context)
     private val statusView = TextView(context)
     private var host: String = ""
     private var port: Int = 0
     private var password: String = ""
+    private var socket: Socket? = null
+    private var input: DataInputStream? = null
+    private var output: DataOutputStream? = null
+    private var readerThread: Thread? = null
+    private val isRunning = AtomicBoolean(false)
+    private var framebuffer: Bitmap? = null
+    private var pixelFormat: PixelFormat? = null
 
     init {
         statusView.text = "VNC viewer inicializado."
-        addView(statusView)
+        statusView.setPadding(24, 16, 24, 16)
+        statusView.setBackgroundColor(0x66000000)
+        statusView.setTextColor(0xFFFFFFFF.toInt())
+        imageView.scaleType = ImageView.ScaleType.FIT_CENTER
+        addView(imageView, LayoutParams(LayoutParams.MATCH_PARENT, LayoutParams.MATCH_PARENT))
+        val statusParams = LayoutParams(LayoutParams.WRAP_CONTENT, LayoutParams.WRAP_CONTENT)
+        statusParams.gravity = Gravity.BOTTOM or Gravity.START
+        addView(statusView, statusParams)
     }
 
     fun setConnectionInfo(host: String, port: Int, password: String) {
@@ -42,7 +71,16 @@ class VncCanvasView @JvmOverloads constructor(
     }
 
     fun connect() {
-        updateStatus("Conexión VNC no implementada en el módulo local.")
+        if (host.isBlank() || port == 0) {
+            updateStatus("Host o puerto inválidos.")
+            return
+        }
+        if (isRunning.get()) {
+            updateStatus("Conexión ya en curso.")
+            return
+        }
+        isRunning.set(true)
+        readerThread = Thread { runConnection() }.apply { start() }
     }
 
     fun startConnection() {
@@ -50,6 +88,24 @@ class VncCanvasView @JvmOverloads constructor(
     }
 
     fun disconnect() {
+        isRunning.set(false)
+        readerThread?.interrupt()
+        readerThread = null
+        try {
+            input?.close()
+        } catch (_: Exception) {
+        }
+        try {
+            output?.close()
+        } catch (_: Exception) {
+        }
+        try {
+            socket?.close()
+        } catch (_: Exception) {
+        }
+        input = null
+        output = null
+        socket = null
         updateStatus("Conexión VNC detenida.")
     }
 
@@ -58,6 +114,235 @@ class VncCanvasView @JvmOverloads constructor(
     }
 
     private fun updateStatus(message: String) {
-        statusView.text = message
+        post { statusView.text = message }
+    }
+
+    private fun runConnection() {
+        try {
+            updateStatus("Conectando a $host:$port ...")
+            val newSocket = Socket()
+            newSocket.connect(InetSocketAddress(host, port), 8000)
+            socket = newSocket
+            input = DataInputStream(BufferedInputStream(newSocket.getInputStream()))
+            output = DataOutputStream(BufferedOutputStream(newSocket.getOutputStream()))
+
+            val serverVersion = ByteArray(12)
+            input?.readFully(serverVersion)
+            output?.write(serverVersion)
+            output?.flush()
+
+            val securityTypesCount = input?.readUnsignedByte() ?: 0
+            if (securityTypesCount == 0) {
+                val reasonLength = input?.readInt() ?: 0
+                val reasonBytes = ByteArray(reasonLength)
+                input?.readFully(reasonBytes)
+                updateStatus("Servidor rechazó: ${String(reasonBytes)}")
+                disconnect()
+                return
+            }
+
+            val securityTypes = ByteArray(securityTypesCount)
+            input?.readFully(securityTypes)
+            val selected = selectSecurityType(securityTypes)
+            output?.writeByte(selected)
+            output?.flush()
+
+            if (selected == SECURITY_VNC_AUTH) {
+                val challenge = ByteArray(16)
+                input?.readFully(challenge)
+                val response = vncAuthResponse(password, challenge)
+                output?.write(response)
+                output?.flush()
+            }
+
+            val securityResult = input?.readInt() ?: 1
+            if (securityResult != 0) {
+                updateStatus("Autenticación fallida.")
+                disconnect()
+                return
+            }
+
+            output?.writeByte(1)
+            output?.flush()
+
+            val width = input?.readUnsignedShort() ?: 0
+            val height = input?.readUnsignedShort() ?: 0
+            val format = readPixelFormat()
+            pixelFormat = format
+            val nameLength = input?.readInt() ?: 0
+            if (nameLength > 0) {
+                val nameBytes = ByteArray(nameLength)
+                input?.readFully(nameBytes)
+            }
+
+            framebuffer = Bitmap.createBitmap(width, height, Bitmap.Config.ARGB_8888)
+            post { imageView.setImageBitmap(framebuffer) }
+            updateStatus("Conectado. ${width}x$height")
+
+            sendSetEncodings()
+            sendFramebufferUpdateRequest(false, 0, 0, width, height)
+
+            while (isRunning.get()) {
+                val messageType = input?.readUnsignedByte() ?: break
+                when (messageType) {
+                    0 -> handleFramebufferUpdate()
+                    2 -> input?.readUnsignedByte()
+                    3 -> handleServerCutText()
+                    else -> {
+                        updateStatus("Mensaje no soportado: $messageType")
+                        disconnect()
+                        return
+                    }
+                }
+            }
+        } catch (e: Exception) {
+            updateStatus("Error VNC: ${e.message}")
+            disconnect()
+        }
+    }
+
+    private fun readPixelFormat(): PixelFormat {
+        val bitsPerPixel = input?.readUnsignedByte() ?: 32
+        val depth = input?.readUnsignedByte() ?: 24
+        val bigEndian = (input?.readUnsignedByte() ?: 0) != 0
+        val trueColor = (input?.readUnsignedByte() ?: 1) != 0
+        val redMax = input?.readUnsignedShort() ?: 255
+        val greenMax = input?.readUnsignedShort() ?: 255
+        val blueMax = input?.readUnsignedShort() ?: 255
+        val redShift = input?.readUnsignedByte() ?: 16
+        val greenShift = input?.readUnsignedByte() ?: 8
+        val blueShift = input?.readUnsignedByte() ?: 0
+        input?.skipBytes(3)
+        return PixelFormat(
+            bitsPerPixel,
+            depth,
+            bigEndian,
+            trueColor,
+            redMax,
+            greenMax,
+            blueMax,
+            redShift,
+            greenShift,
+            blueShift
+        )
+    }
+
+    private fun sendSetEncodings() {
+        output?.writeByte(2)
+        output?.writeByte(0)
+        output?.writeShort(1)
+        output?.writeInt(0)
+        output?.flush()
+    }
+
+    private fun sendFramebufferUpdateRequest(incremental: Boolean, x: Int, y: Int, width: Int, height: Int) {
+        output?.writeByte(3)
+        output?.writeByte(if (incremental) 1 else 0)
+        output?.writeShort(x)
+        output?.writeShort(y)
+        output?.writeShort(width)
+        output?.writeShort(height)
+        output?.flush()
+    }
+
+    private fun handleFramebufferUpdate() {
+        input?.skipBytes(1)
+        val numberOfRectangles = input?.readUnsignedShort() ?: 0
+        val format = pixelFormat ?: return
+        val bitmap = framebuffer ?: return
+        repeat(numberOfRectangles) {
+            val x = input?.readUnsignedShort() ?: 0
+            val y = input?.readUnsignedShort() ?: 0
+            val width = input?.readUnsignedShort() ?: 0
+            val height = input?.readUnsignedShort() ?: 0
+            val encoding = input?.readInt() ?: 0
+            if (encoding != 0) {
+                updateStatus("Encoding no soportado: $encoding")
+                disconnect()
+                return
+            }
+            val bytesPerPixel = format.bitsPerPixel / 8
+            val dataLength = width * height * bytesPerPixel
+            val data = ByteArray(dataLength)
+            input?.readFully(data)
+            val pixels = IntArray(width * height)
+            decodePixels(data, pixels, format, bytesPerPixel)
+            bitmap.setPixels(pixels, 0, width, x, y, width, height)
+        }
+        post { imageView.invalidate() }
+        sendFramebufferUpdateRequest(true, 0, 0, bitmap.width, bitmap.height)
+    }
+
+    private fun decodePixels(data: ByteArray, pixels: IntArray, format: PixelFormat, bytesPerPixel: Int) {
+        val order = if (format.bigEndian) ByteOrder.BIG_ENDIAN else ByteOrder.LITTLE_ENDIAN
+        val buffer = ByteBuffer.wrap(data).order(order)
+        for (i in pixels.indices) {
+            val value = when (bytesPerPixel) {
+                4 -> buffer.int
+                2 -> buffer.short.toInt() and 0xFFFF
+                1 -> buffer.get().toInt() and 0xFF
+                else -> buffer.int
+            }
+            val red = ((value shr format.redShift) and format.redMax) * 255 / format.redMax
+            val green = ((value shr format.greenShift) and format.greenMax) * 255 / format.greenMax
+            val blue = ((value shr format.blueShift) and format.blueMax) * 255 / format.blueMax
+            pixels[i] = (0xFF shl 24) or (red shl 16) or (green shl 8) or blue
+        }
+    }
+
+    private fun handleServerCutText() {
+        input?.skipBytes(3)
+        val length = input?.readInt() ?: 0
+        if (length > 0) {
+            input?.skipBytes(length)
+        }
+    }
+
+    private fun selectSecurityType(types: ByteArray): Int {
+        return when {
+            types.contains(SECURITY_NONE) -> SECURITY_NONE
+            types.contains(SECURITY_VNC_AUTH) && password.isNotBlank() -> SECURITY_VNC_AUTH
+            else -> SECURITY_NONE
+        }
+    }
+
+    private fun vncAuthResponse(password: String, challenge: ByteArray): ByteArray {
+        val key = ByteArray(8)
+        val passBytes = password.toByteArray()
+        for (i in 0 until 8) {
+            val b = if (i < passBytes.size) passBytes[i] else 0
+            key[i] = reverseBits(b)
+        }
+        val cipher = Cipher.getInstance("DES/ECB/NoPadding")
+        cipher.init(Cipher.ENCRYPT_MODE, SecretKeySpec(key, "DES"))
+        return cipher.doFinal(challenge)
+    }
+
+    private fun reverseBits(value: Byte): Byte {
+        var v = value.toInt()
+        var result = 0
+        for (i in 0 until 8) {
+            result = (result shl 1) or (v and 1)
+            v = v shr 1
+        }
+        return result.toByte()
+    }
+
+    private data class PixelFormat(
+        val bitsPerPixel: Int,
+        val depth: Int,
+        val bigEndian: Boolean,
+        val trueColor: Boolean,
+        val redMax: Int,
+        val greenMax: Int,
+        val blueMax: Int,
+        val redShift: Int,
+        val greenShift: Int,
+        val blueShift: Int
+    )
+
+    private companion object {
+        const val SECURITY_NONE = 1
+        const val SECURITY_VNC_AUTH = 2
     }
 }

--- a/vncviewer/src/main/java/android/vnc/VncCanvasView.kt
+++ b/vncviewer/src/main/java/android/vnc/VncCanvasView.kt
@@ -300,8 +300,8 @@ class VncCanvasView @JvmOverloads constructor(
 
     private fun selectSecurityType(types: ByteArray): Int {
         return when {
-            types.contains(SECURITY_NONE) -> SECURITY_NONE
-            types.contains(SECURITY_VNC_AUTH) && password.isNotBlank() -> SECURITY_VNC_AUTH
+            types.contains(SECURITY_NONE.toByte()) -> SECURITY_NONE
+            types.contains(SECURITY_VNC_AUTH.toByte()) && password.isNotBlank() -> SECURITY_VNC_AUTH
             else -> SECURITY_NONE
         }
     }


### PR DESCRIPTION
### Motivation
- Integrate VNC streaming and remote control into the Android client so the app can query VNC health/status and start/stop the x11vnc server and open a VNC stream as specified by the integration spec.

### Description
- Add `VncApiClient` to call backend endpoints (`/health`, `/vnc/status`, `/vnc/start`, `/vnc/stop`) and parse the VNC status JSON into `VncInfo`/`VncStatusResponse` models.
- Add `VncConnectionActivity` plus layout `activity_vnc_connection.xml` to provide a connection UI, query backend health/status, prompt to start VNC if enabled but stopped, stop VNC, persist VNC port/password, and launch an external VNC client with a `vnc://` intent.
- Surface the VNC flow in the app navigation by adding a drawer entry, new strings, and registering the activity in `AndroidManifest.xml`, and add a click handler in `MainActivity` to open the new screen.
- Use existing `NetworkUtils` OkHttp client (trust-all client used here for development) and Gson for JSON parsing; map `localhost_only` JSON key with `@SerializedName`.

### Testing
- Attempted a smoke test by running `./gradlew testDebugUnitTest` which failed during the Gradle build due to missing build tools (`25.0.1`), so unit tests could not complete.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696b74bf919083259f96b14068a2e04f)